### PR TITLE
Allow Field to store dataclass.field.metadata

### DIFF
--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -83,7 +83,7 @@ class BaseField:
             return singular
         return name
 
-    def render_metadata(self) -> typing.List[typing.Tuple[str, str]]:
+    def get_metadata(self) -> typing.List[typing.Tuple[str, str]]:
         meta_data_for_template = []
         if type(self.metadata) == dict:
             for name, value in self.metadata.items():
@@ -112,7 +112,7 @@ class BaseField:
         """
         template = OrderedDict(
             [("name", self.name), ("type", self.get_avro_type())]
-            + self.render_metadata()
+            + self.get_metadata()
         )
 
         default = self.get_default_value()

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -110,7 +110,10 @@ class BaseField:
                 * tuple, he OrderedDict will contains the key symbols inside type
                 * dict, he OrderedDict will contains the key values inside type
         """
-        template = OrderedDict([("name", self.name), ("type", self.get_avro_type())] + self.render_metadata())
+        template = OrderedDict(
+            [("name", self.name), ("type", self.get_avro_type())]
+            + self.render_metadata()
+        )
 
         default = self.get_default_value()
         if default is not None:
@@ -578,14 +581,16 @@ def field_factory(
     native_type: typing.Any,
     default: typing.Any = dataclasses.MISSING,
     default_factory: typing.Any = dataclasses.MISSING,
-    metadata: typing.Dict = dataclasses.MISSING
+    metadata: typing.Dict = dataclasses.MISSING,
 ):
 
     if native_type in PYTHON_INMUTABLE_TYPES:
         klass = INMUTABLE_FIELDS_CLASSES[native_type]
         return klass(name=name, type=native_type, default=default, metadata=metadata)
     elif utils.is_self_referenced(native_type):
-        return SelfReferenceField(name=name, type=native_type, default=default, metadata=metadata)
+        return SelfReferenceField(
+            name=name, type=native_type, default=default, metadata=metadata
+        )
     elif isinstance(native_type, typing._GenericAlias):
         origin = native_type.__origin__
 
@@ -611,13 +616,15 @@ def field_factory(
             type=native_type,
             default=default,
             default_factory=default_factory,
-            metadata=metadata
+            metadata=metadata,
         )
     elif native_type in PYTHON_LOGICAL_TYPES:
         klass = LOGICAL_TYPES_FIELDS_CLASSES[native_type]
         return klass(name=name, type=native_type, default=default, metadata=metadata)
     else:
-        return RecordField(name=name, type=native_type, default=default, metadata=metadata)
+        return RecordField(
+            name=name, type=native_type, default=default, metadata=metadata
+        )
 
 
 Field = field_factory

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -331,9 +331,9 @@ class UnionField(BaseField):
 
     @staticmethod
     def generate_union(
-            elements: typing.List,
-            default: typing.Any = None,
-            default_factory: typing.Callable = dataclasses.MISSING,
+        elements: typing.List,
+        default: typing.Any = None,
+        default_factory: typing.Callable = dataclasses.MISSING,
     ):
         """
         Generate union.
@@ -578,29 +578,31 @@ PRIMITIVE_LOGICAL_TYPES_FIELDS_CLASSES = {
 
 
 def field_factory(
-        name: str,
-        native_type: typing.Any,
-        default: typing.Any = dataclasses.MISSING,
-        default_factory: typing.Any = dataclasses.MISSING,
-        metadata: typing.Dict = dataclasses.MISSING
+    name: str,
+    native_type: typing.Any,
+    default: typing.Any = dataclasses.MISSING,
+    default_factory: typing.Any = dataclasses.MISSING,
+    metadata: typing.Dict = dataclasses.MISSING,
 ):
     if native_type in PYTHON_INMUTABLE_TYPES:
         klass = INMUTABLE_FIELDS_CLASSES[native_type]
         return klass(name=name, type=native_type, default=default, metadata=metadata)
     elif utils.is_self_referenced(native_type):
-        return SelfReferenceField(name=name, type=native_type, default=default, metadata=metadata)
+        return SelfReferenceField(
+            name=name, type=native_type, default=default, metadata=metadata
+        )
     elif isinstance(native_type, typing._GenericAlias):
         origin = native_type.__origin__
 
         if origin not in (
-                tuple,
-                list,
-                dict,
-                typing.Union,
-                collections.abc.Sequence,
-                collections.abc.MutableSequence,
-                collections.abc.Mapping,
-                collections.abc.MutableMapping,
+            tuple,
+            list,
+            dict,
+            typing.Union,
+            collections.abc.Sequence,
+            collections.abc.MutableSequence,
+            collections.abc.Mapping,
+            collections.abc.MutableMapping,
         ):
             raise ValueError(
                 f"""
@@ -614,13 +616,15 @@ def field_factory(
             type=native_type,
             default=default,
             default_factory=default_factory,
-            metadata=metadata
+            metadata=metadata,
         )
     elif native_type in PYTHON_LOGICAL_TYPES:
         klass = LOGICAL_TYPES_FIELDS_CLASSES[native_type]
         return klass(name=name, type=native_type, default=default, metadata=metadata)
     else:
-        return RecordField(name=name, type=native_type, default=default, metadata=metadata)
+        return RecordField(
+            name=name, type=native_type, default=default, metadata=metadata
+        )
 
 
 Field = field_factory

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -83,7 +83,7 @@ class BaseField:
             return singular
         return name
 
-    def get_metadata(self):
+    def render_metadata(self) -> typing.List[typing.Tuple[str, str]]:
         meta_data_for_template = []
         if type(self.metadata) == dict:
             for name, value in self.metadata.items():
@@ -110,7 +110,7 @@ class BaseField:
                 * tuple, he OrderedDict will contains the key symbols inside type
                 * dict, he OrderedDict will contains the key values inside type
         """
-        template = OrderedDict([("name", self.name), ("type", self.get_avro_type())] + self.get_metadata())
+        template = OrderedDict([("name", self.name), ("type", self.get_avro_type())] + self.render_metadata())
 
         default = self.get_default_value()
         if default is not None:

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -111,8 +111,7 @@ class BaseField:
                 * dict, he OrderedDict will contains the key values inside type
         """
         template = OrderedDict(
-            [("name", self.name), ("type", self.get_avro_type())]
-            + self.get_metadata()
+            [("name", self.name), ("type", self.get_avro_type())] + self.get_metadata()
         )
 
         default = self.get_default_value()

--- a/dataclasses_avroschema/schema_definition.py
+++ b/dataclasses_avroschema/schema_definition.py
@@ -70,6 +70,7 @@ class AvroSchemaDefinition(BaseSchemaDefinition):
                 dataclass_field.type,
                 dataclass_field.default,
                 dataclass_field.default_factory,
+                dataclass_field.metadata
             )
             for dataclass_field in dataclasses.fields(self.klass_or_instance)
         ]

--- a/dataclasses_avroschema/schema_definition.py
+++ b/dataclasses_avroschema/schema_definition.py
@@ -70,7 +70,7 @@ class AvroSchemaDefinition(BaseSchemaDefinition):
                 dataclass_field.type,
                 dataclass_field.default,
                 dataclass_field.default_factory,
-                dataclass_field.metadata
+                dataclass_field.metadata,
             )
             for dataclass_field in dataclasses.fields(self.klass_or_instance)
         ]

--- a/dataclasses_avroschema/schema_definition.py
+++ b/dataclasses_avroschema/schema_definition.py
@@ -70,7 +70,7 @@ class AvroSchemaDefinition(BaseSchemaDefinition):
                 dataclass_field.type,
                 dataclass_field.default,
                 dataclass_field.default_factory,
-                dataclass_field.metadata,
+                dataclass_field.metadata
             )
             for dataclass_field in dataclasses.fields(self.klass_or_instance)
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,11 @@ def user_dataclass():
 def user_dataclass_with_field_metadata():
     @dataclasses.dataclass(repr=False)
     class User:
-        name: str = dataclasses.field(metadata={'classification': 'test'})
-        age: int = dataclasses.field(metadata={'classification': 'test'})
-        has_pets: bool = dataclasses.field(metadata={'classification': 'test'})
-        money: float = dataclasses.field(metadata={'classification': 'test'})
-        encoded: bytes = dataclasses.field(metadata={'classification': 'test'})
+        name: str = dataclasses.field(metadata={"classification": "test"})
+        age: int = dataclasses.field(metadata={"classification": "test"})
+        has_pets: bool = dataclasses.field(metadata={"classification": "test"})
+        money: float = dataclasses.field(metadata={"classification": "test"})
+        encoded: bytes = dataclasses.field(metadata={"classification": "test"})
 
     return User
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,19 @@ def user_dataclass():
 
 
 @pytest.fixture
+def user_dataclass_with_field_metadata():
+    @dataclasses.dataclass(repr=False)
+    class User:
+        name: str = dataclasses.field(metadata={'classification': 'test'})
+        age: int = dataclasses.field(metadata={'classification': 'test'})
+        has_pets: bool = dataclasses.field(metadata={'classification': 'test'})
+        money: float = dataclasses.field(metadata={'classification': 'test'})
+        encoded: bytes = dataclasses.field(metadata={'classification': 'test'})
+
+    return User
+
+
+@pytest.fixture
 def user_v2_dataclass():
     @dataclasses.dataclass(repr=False)
     class UserV2:

--- a/tests/fields/test_BaseField.py
+++ b/tests/fields/test_BaseField.py
@@ -1,0 +1,73 @@
+import dataclasses
+import typing
+
+from dataclasses_avroschema import fields
+
+
+def test_render():
+    field = fields.Field('first_name', str, fields.NULL, metadata={'desc': 'English Language Name'})
+
+    expected = {
+        "name": "first_name",
+        "type": [
+            "string",
+            fields.NULL
+        ],
+        "default": fields.NULL,
+        "desc": "English Language Name"
+    }
+
+    assert expected == field.render()
+
+    field = fields.Field('engine_name', str, fields.NULL)
+
+    expected = {
+        "name": "engine_name",
+        "type": [
+            "string",
+            fields.NULL
+        ],
+        "default": fields.NULL
+    }
+
+    assert expected == field.render()
+
+    field = fields.Field('breed_name', str, fields.NULL, metadata={'encoding': 'some_exotic_encoding', 'doc': 'Official Breed Name'})
+
+    expected = {
+        "name": "breed_name",
+        "type": [
+            "string",
+            fields.NULL
+        ],
+        "default": fields.NULL,
+        "encoding": "some_exotic_encoding",
+        "doc": "Official Breed Name",
+    }
+
+    assert expected == field.render()
+
+
+def test_render_metadata():
+    field = fields.Field('first_name', str, fields.NULL, metadata={'desc': 'English Language Name'})
+
+    expected = [
+        ("desc", "English Language Name")
+    ]
+
+    assert expected == field.render_metadata()
+
+    field = fields.Field('engine_name', str, fields.NULL)
+
+    expected = []
+
+    assert expected == field.render_metadata()
+
+    field = fields.Field('breed_name', str, fields.NULL, metadata={'encoding': 'some_exotic_encoding', 'doc': 'Official Breed Name'})
+
+    expected = [
+        ("encoding", "some_exotic_encoding"),
+        ("doc", "Official Breed Name")
+    ]
+
+    assert expected == field.render_metadata()

--- a/tests/fields/test_BaseField.py
+++ b/tests/fields/test_BaseField.py
@@ -50,13 +50,13 @@ def test_render_metadata():
 
     expected = [("desc", "English Language Name")]
 
-    assert expected == field.render_metadata()
+    assert expected == field.get_metadata()
 
     field = fields.Field("engine_name", str, fields.NULL)
 
     expected = []
 
-    assert expected == field.render_metadata()
+    assert expected == field.get_metadata()
 
     field = fields.Field(
         "breed_name",
@@ -67,4 +67,4 @@ def test_render_metadata():
 
     expected = [("encoding", "some_exotic_encoding"), ("doc", "Official Breed Name")]
 
-    assert expected == field.render_metadata()
+    assert expected == field.get_metadata()

--- a/tests/fields/test_BaseField.py
+++ b/tests/fields/test_BaseField.py
@@ -1,6 +1,3 @@
-import dataclasses
-import typing
-
 from dataclasses_avroschema import fields
 
 

--- a/tests/fields/test_BaseField.py
+++ b/tests/fields/test_BaseField.py
@@ -5,41 +5,39 @@ from dataclasses_avroschema import fields
 
 
 def test_render():
-    field = fields.Field('first_name', str, fields.NULL, metadata={'desc': 'English Language Name'})
+    field = fields.Field(
+        "first_name", str, fields.NULL, metadata={"desc": "English Language Name"}
+    )
 
     expected = {
         "name": "first_name",
-        "type": [
-            "string",
-            fields.NULL
-        ],
+        "type": ["string", fields.NULL],
         "default": fields.NULL,
-        "desc": "English Language Name"
+        "desc": "English Language Name",
     }
 
     assert expected == field.render()
 
-    field = fields.Field('engine_name', str, fields.NULL)
+    field = fields.Field("engine_name", str, fields.NULL)
 
     expected = {
         "name": "engine_name",
-        "type": [
-            "string",
-            fields.NULL
-        ],
-        "default": fields.NULL
+        "type": ["string", fields.NULL],
+        "default": fields.NULL,
     }
 
     assert expected == field.render()
 
-    field = fields.Field('breed_name', str, fields.NULL, metadata={'encoding': 'some_exotic_encoding', 'doc': 'Official Breed Name'})
+    field = fields.Field(
+        "breed_name",
+        str,
+        fields.NULL,
+        metadata={"encoding": "some_exotic_encoding", "doc": "Official Breed Name"},
+    )
 
     expected = {
         "name": "breed_name",
-        "type": [
-            "string",
-            fields.NULL
-        ],
+        "type": ["string", fields.NULL],
         "default": fields.NULL,
         "encoding": "some_exotic_encoding",
         "doc": "Official Breed Name",
@@ -49,25 +47,27 @@ def test_render():
 
 
 def test_render_metadata():
-    field = fields.Field('first_name', str, fields.NULL, metadata={'desc': 'English Language Name'})
+    field = fields.Field(
+        "first_name", str, fields.NULL, metadata={"desc": "English Language Name"}
+    )
 
-    expected = [
-        ("desc", "English Language Name")
-    ]
+    expected = [("desc", "English Language Name")]
 
     assert expected == field.render_metadata()
 
-    field = fields.Field('engine_name', str, fields.NULL)
+    field = fields.Field("engine_name", str, fields.NULL)
 
     expected = []
 
     assert expected == field.render_metadata()
 
-    field = fields.Field('breed_name', str, fields.NULL, metadata={'encoding': 'some_exotic_encoding', 'doc': 'Official Breed Name'})
+    field = fields.Field(
+        "breed_name",
+        str,
+        fields.NULL,
+        metadata={"encoding": "some_exotic_encoding", "doc": "Official Breed Name"},
+    )
 
-    expected = [
-        ("encoding", "some_exotic_encoding"),
-        ("doc", "Official Breed Name")
-    ]
+    expected = [("encoding", "some_exotic_encoding"), ("doc", "Official Breed Name")]
 
     assert expected == field.render_metadata()

--- a/tests/schemas/avro/user_with_field_metadata.avsc
+++ b/tests/schemas/avro/user_with_field_metadata.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {"name": "name", "type": "string", "classification":  "test"},
+    {"name": "age", "type": "int", "classification":  "test"},
+    {"name": "has_pets", "type": "boolean", "classification":  "test"},
+    {"name": "money", "type": "float", "classification":  "test"},
+    {"name": "encoded", "type": "bytes", "classification":  "test"}
+  ]
+}

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -22,6 +22,11 @@ def user_avro_json():
 
 
 @pytest.fixture
+def user_with_field_metadata_avro_json():
+    return load_json("user_with_field_metadata.avsc")
+
+
+@pytest.fixture
 def user_v2_avro_json():
     return load_json("user_v2.avsc")
 

--- a/tests/schemas/test_fastavro_paser_schema_.py
+++ b/tests/schemas/test_fastavro_paser_schema_.py
@@ -24,6 +24,22 @@ def test_minimal_schema(user_dataclass):
     assert parse_schema(schema)
 
 
+def test_schema_with_field_metadata(user_dataclass_with_field_metadata):
+    """
+    Python class contains the primitive types:
+
+    class User:
+        name: str
+        age: int
+        has_pets: bool
+        money: float
+        encoded: bytes
+    """
+    schema = SchemaGenerator(user_dataclass_with_field_metadata).avro_schema_to_python()
+
+    assert parse_schema(schema)
+
+
 def test_schema_with_extra_avro_attrs(user_extra_avro_atributes_dataclass):
     """
     Python class contains the primitive types plus aliases and namespace

--- a/tests/schemas/test_schema.py
+++ b/tests/schemas/test_schema.py
@@ -21,8 +21,8 @@ def test_total_schema_fields_from_instance(user_dataclass):
 
 
 def test_schema_render_from_class_with_field_metadata(
-        user_dataclass_with_field_metadata,
-        user_with_field_metadata_avro_json):
+    user_dataclass_with_field_metadata, user_with_field_metadata_avro_json
+):
     user_schema = SchemaGenerator(
         user_dataclass_with_field_metadata, include_schema_doc=False
     ).avro_schema()

--- a/tests/schemas/test_schema.py
+++ b/tests/schemas/test_schema.py
@@ -20,6 +20,16 @@ def test_total_schema_fields_from_instance(user_dataclass):
     assert len(schema_generator.get_fields) == 5
 
 
+def test_schema_render_from_class_with_field_metadata(
+        user_dataclass_with_field_metadata,
+        user_with_field_metadata_avro_json):
+    user_schema = SchemaGenerator(
+        user_dataclass_with_field_metadata, include_schema_doc=False
+    ).avro_schema()
+
+    assert user_schema == json.dumps(user_with_field_metadata_avro_json)
+
+
 def test_schema_render_from_class(user_dataclass, user_avro_json):
     user_schema = SchemaGenerator(
         user_dataclass, include_schema_doc=False


### PR DESCRIPTION
This PR implements the ability to store the `metadata` dict defined on a `dataclasses.dataclass` field. The use case is that we use custom field-level attributes to classify our data, e.g.:

```json
fields = [
    {
	"type": "string",
	"name": "customer_name",
	"classification": "sensitive"
    },
    {
	"type": "string",
	"name": "reason_of_call",
	"classification": "non-sensitive"
    }
]
```

Ultimately, this will allow the above to be produced from defining dataclasses which have the `metadata` field property defined, e.g.:

```python
import dataclasses

@dataclasses.dataclass
class Call:
    customer_name: str = dataclasses.field(metadata={'classification': 'sensitive'})
    reason_of_call: str = dataclasses.field(metadata={'classification': 'non-sensitive'}
```
