### PR TITLE
Deal with None and MISSING on LogicalTypeField and RecordField

### DIFF
--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -407,6 +407,12 @@ class SelfReferenceField(BaseField):
 
 class LogicalTypeField(BaseField):
     def get_avro_type(self):
+        if self.default is not dataclasses.MISSING:
+            if self.default is not None:
+                return [self.avro_type, NULL]
+            # means that default value is None
+            return [NULL, self.avro_type]
+
         return self.avro_type
 
 
@@ -556,7 +562,12 @@ class UUIDField(LogicalTypeField):
 @dataclasses.dataclass
 class RecordField(BaseField):
     def get_avro_type(self):
-        return self.type.avro_schema_to_python()
+        record_type = self.type.avro_schema_to_python()
+        if self.default is not dataclasses.MISSING:
+            if self.default is not None:
+                return [record_type, NULL]
+        # means that default value is None
+        return [NULL, record_type]
 
 
 INMUTABLE_FIELDS_CLASSES = {

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -409,7 +409,7 @@ class LogicalTypeField(BaseField):
     def get_avro_type(self):
         if self.default is not dataclasses.MISSING:
             if self.default is not None:
-                return [self.avro_type, NULL]
+                return self.avro_type
             # means that default value is None
             return [NULL, self.avro_type]
 
@@ -565,9 +565,11 @@ class RecordField(BaseField):
         record_type = self.type.avro_schema_to_python()
         if self.default is not dataclasses.MISSING:
             if self.default is not None:
-                return [record_type, NULL]
+                return record_type
         # means that default value is None
-        return [NULL, record_type]
+            return [NULL, record_type]
+
+        return record_type
 
 
 INMUTABLE_FIELDS_CLASSES = {

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -27,7 +27,7 @@ def test_logical_types_with_null_as_default(python_type, avro_type, logical_type
 
     expected = {
         "name": name,
-        "type": {"type": avro_type, "logicalType": logical_type},
+        "type": ["null", {"type": avro_type, "logicalType": logical_type}],
         "default": fields.NULL,
     }
 

--- a/tests/schemas/avro/user_one_address_with_none_default.avsc
+++ b/tests/schemas/avro/user_one_address_with_none_default.avsc
@@ -1,0 +1,37 @@
+{
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "age",
+            "type": "int"
+        },
+        {
+            "name": "address",
+            "type": [
+                "null",
+                {
+                "type": "record",
+                "name": "Address",
+                "fields": [
+                    {
+                        "name": "street",
+                        "type": "string"
+                    },
+                    {
+                        "name": "street_number",
+                        "type": "int"
+                    }
+                ],
+                "doc": "An Address"
+                }
+            ],
+            "default": "null"
+        } 
+    ],
+    "doc": "An User with Address"
+}

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -53,6 +53,11 @@ def user_one_address_schema():
 
 
 @pytest.fixture
+def user_one_address_schema_with_none_default():
+    return load_json("user_one_address_with_none_default.avsc")
+
+
+@pytest.fixture
 def user_many_address_schema():
     return load_json("user_many_address.avsc")
 

--- a/tests/schemas/test_faust_schema.py
+++ b/tests/schemas/test_faust_schema.py
@@ -92,6 +92,25 @@ def test_faust_record_one_to_one_relationship(user_one_address_schema):
     assert User.avro_schema() == json.dumps(user_one_address_schema)
 
 
+def test_faust_record_one_to_one_relationship_with_none_default(user_one_address_schema_with_none_default):
+    """
+    Test schema relationship one-to-one
+    """
+
+    class Address(faust.Record, AvroModel):
+        "An Address"
+        street: str
+        street_number: int
+
+    class User(faust.Record, AvroModel):
+        "An User with Address"
+        name: str
+        age: int
+        address: Address = None
+
+    assert User.avro_schema() == json.dumps(user_one_address_schema_with_none_default)
+
+
 def test_faust_record_one_to_many_relationship(user_many_address_schema):
     """
     Test schema relationship one-to-many


### PR DESCRIPTION
I choose the less intrusive approach.

But maybe it would be smarter to deal with the fields nullability in a more global way in `BaseField.render`. Where the default value is also managed.

something like : 

```python
    def render(self) -> OrderedDict:
        final_avro_type = self.get_avro_type()
        if self.default is not dataclasses.MISSING:
            if self.default is not None:
                final_avro_type = [self.avro_type, NULL]
                # means that default value is None
            final_avro_type = [NULL, self.avro_type]

        template = OrderedDict([("name", self.name), ("type", final_avro_type)] + self.get_metadata())

        default = self.get_default_value()
        if default is not None:
            template["default"] = default

        return template

```
