### PR TITLE
Changed Avro type for Python int to long

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Generate [Avro](https://avro.apache.org/docs/1.8.2/spec.html) Schemas from a Pyt
 [![codecov](https://codecov.io/gh/marcosschroh/dataclasses-avroschema/branch/master/graph/badge.svg)](https://codecov.io/gh/marcosschroh/dataclasses-avroschema)
 ![python version](https://img.shields.io/badge/python-3.7%2B-yellowgreen)
 
+## Notice of breaking change
+
+As of version **0.19.0**, the default Avro type for Python ints has been changed from `int` to `long` and the default Avro
+type for Python floats has been changed from `float` to `double`. Please take care when upgrading.
+
 ## Requirements
 
 `python 3.7+`

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -38,6 +38,24 @@ LOGICAL_TIME = {"type": INT, "logicalType": TIME_MILLIS}
 LOGICAL_DATETIME = {"type": LONG, "logicalType": TIMESTAMP_MILLIS}
 LOGICAL_UUID = {"type": STRING, "logicalType": UUID}
 
+PYTHON_TYPE_TO_AVRO = {
+    bool: BOOLEAN,
+    type(None): NULL,
+    int: LONG,
+    float: DOUBLE,
+    bytes: BYTES,
+    str: STRING,
+    list: {"type": ARRAY},
+    tuple: {"type": ARRAY},
+    dict: {"type": MAP},
+    types.Fixed: {"type": FIXED},
+    types.Enum: {"type": ENUM},
+    datetime.date: {"type": INT, "logicalType": DATE},
+    datetime.time: {"type": INT, "logicalType": TIME_MILLIS},
+    datetime.datetime: {"type": LONG, "logicalType": TIMESTAMP_MILLIS},
+    uuid.uuid4: {"type": STRING, "logicalType": UUID},
+}
+
 # excluding tuple because is a container
 PYTHON_INMUTABLE_TYPES = (str, int, bool, float, bytes, type(None))
 
@@ -181,7 +199,7 @@ class BooleanField(InmutableField):
 
 @dataclasses.dataclass
 class DoubleField(InmutableField):
-    avro_type: typing.ClassVar = FLOAT
+    avro_type: typing.ClassVar = DOUBLE
 
     def fake(self) -> float:
         return fake.pyfloat()

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -22,6 +22,7 @@ NULL = "null"
 INT = "int"
 FLOAT = "float"
 LONG = "long"
+DOUBLE = "double"
 BYTES = "bytes"
 STRING = "string"
 ARRAY = "array"
@@ -36,24 +37,6 @@ LOGICAL_DATE = {"type": INT, "logicalType": DATE}
 LOGICAL_TIME = {"type": INT, "logicalType": TIME_MILLIS}
 LOGICAL_DATETIME = {"type": LONG, "logicalType": TIMESTAMP_MILLIS}
 LOGICAL_UUID = {"type": STRING, "logicalType": UUID}
-
-PYTHON_TYPE_TO_AVRO = {
-    bool: BOOLEAN,
-    type(None): NULL,
-    int: INT,
-    float: FLOAT,
-    bytes: BYTES,
-    str: STRING,
-    list: {"type": ARRAY},
-    tuple: {"type": ARRAY},
-    dict: {"type": MAP},
-    types.Fixed: {"type": FIXED},
-    types.Enum: {"type": ENUM},
-    datetime.date: {"type": INT, "logicalType": DATE},
-    datetime.time: {"type": INT, "logicalType": TIME_MILLIS},
-    datetime.datetime: {"type": LONG, "logicalType": TIMESTAMP_MILLIS},
-    uuid.uuid4: {"type": STRING, "logicalType": UUID},
-}
 
 # excluding tuple because is a container
 PYTHON_INMUTABLE_TYPES = (str, int, bool, float, bytes, type(None))
@@ -181,8 +164,8 @@ class StringField(InmutableField):
 
 
 @dataclasses.dataclass
-class IntegerField(InmutableField):
-    avro_type: typing.ClassVar = INT
+class LongField(InmutableField):
+    avro_type: typing.ClassVar = LONG
 
     def fake(self) -> int:
         return fake.pyint()
@@ -197,7 +180,7 @@ class BooleanField(InmutableField):
 
 
 @dataclasses.dataclass
-class FloatField(InmutableField):
+class DoubleField(InmutableField):
     avro_type: typing.ClassVar = FLOAT
 
     def fake(self) -> float:
@@ -639,8 +622,8 @@ class RecordField(BaseField):
 
 INMUTABLE_FIELDS_CLASSES = {
     bool: BooleanField,
-    int: IntegerField,
-    float: FloatField,
+    int: LongField,
+    float: DoubleField,
     bytes: BytesField,
     str: StringField,
     type(None): NoneField,
@@ -677,8 +660,9 @@ LOGICAL_CLASSES = LOGICAL_TYPES_FIELDS_CLASSES.keys()
 
 FieldType = typing.Union[
     StringField,
+    LongField,
     BooleanField,
-    FloatField,
+    DoubleField,
     BytesField,
     NoneField,
     ListField,

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,11 @@ Generate [Avro](https://avro.apache.org/docs/1.8.2/spec.html) Schemas from a Pyt
 [![codecov](https://codecov.io/gh/marcosschroh/dataclasses-avroschema/branch/master/graph/badge.svg)](https://codecov.io/gh/marcosschroh/dataclasses-avroschema)
 ![python version](https://img.shields.io/badge/python-3.7%2B-yellowgreen)
 
+## Notice of breaking change
+
+As of version **0.19.0**, the default Avro type for Python ints has been changed from `int` to `long` and the default Avro
+type for Python floats has been changed from `float` to `double`. Please take care when upgrading.
+
 ## Requirements
 
 `python 3.7+`

--- a/docs/primitive_types.md
+++ b/docs/primitive_types.md
@@ -3,11 +3,11 @@ The following list represent the avro primitive types mapped to python types:
 | Avro Type | Python Type |
 |-----------|-------------|
 | string    |     str     |
-| int       |     int     |
+| long      |     int     |
 | boolean   |     bool    |
-| float     |     float   |
+| double    |     float   |
 | null      |     None    |
-| bytes     |     bytes     |
+| bytes     |     bytes   |
 
 
 Example:

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -8,9 +8,9 @@ now = datetime.datetime.now()
 
 PRIMITIVE_TYPES = (
     (str, fields.STRING),
-    (int, fields.INT),
+    (int, fields.LONG),
     (bool, fields.BOOLEAN),
-    (float, fields.FLOAT),
+    (float, fields.DOUBLE),
     (bytes, fields.BYTES),
 )
 
@@ -32,9 +32,9 @@ PRIMITIVE_TYPES_AND_INVALID_DEFAULTS = (
 
 LIST_TYPE_AND_ITEMS_TYPE = (
     (str, "string"),
-    (int, "int"),
+    (int, "long"),
     (bool, "boolean"),
-    (float, "float"),
+    (float, "double"),
     (bytes, "bytes"),
 )
 
@@ -46,7 +46,7 @@ LOGICAL_TYPES = (
 )
 
 UNION_PRIMITIVE_ELEMENTS = (
-    ((str, int), (fields.STRING, fields.INT), "test"),
+    ((str, int), (fields.STRING, fields.LONG), "test"),
     ((str, bytes), (fields.STRING, fields.BYTES), b"test"),
     ((str, None), (fields.STRING, fields.NULL), None),
     (
@@ -57,18 +57,18 @@ UNION_PRIMITIVE_ELEMENTS = (
         ),
         now,
     ),
-    ((float, str, int), (fields.FLOAT, fields.STRING, fields.INT), 100.0),
-    ((str, float, int, bool), (fields.STRING, fields.FLOAT, fields.INT, fields.BOOLEAN), False),
+    ((float, str, int), (fields.DOUBLE, fields.STRING, fields.LONG), 100.0),
+    ((str, float, int, bool), (fields.STRING, fields.DOUBLE, fields.LONG, fields.BOOLEAN), False),
 )
 
 UNION_WITH_ARRAY = (
     (
         (typing.List[int], str),
-        (fields.INT, fields.STRING),
+        (fields.LONG, fields.STRING),
     ),
     (
         (typing.List[str], float),
-        (fields.STRING, fields.FLOAT),
+        (fields.STRING, fields.DOUBLE),
     ),
     (
         (typing.List[datetime.datetime], datetime.datetime),
@@ -83,11 +83,11 @@ UNION_WITH_ARRAY = (
 UNION_WITH_MAP = (
     (
         (typing.Dict[str, int], str),
-        (fields.INT, fields.STRING),
+        (fields.LONG, fields.STRING),
     ),
     (
         (typing.Dict[str, str], float),
-        (fields.STRING, fields.FLOAT),
+        (fields.STRING, fields.DOUBLE),
     ),
     (
         (typing.Dict[str, datetime.datetime], datetime.datetime),
@@ -105,7 +105,7 @@ OPTIONAL_UNION_COMPLEX_TYPES = (
         typing.List[datetime.datetime],
         {"type": fields.ARRAY, "items": fields.LOGICAL_DATETIME, "name": "optional_field"},
     ),
-    (typing.Dict[str, int], {"type": fields.MAP, "values": fields.INT, "name": "optional_field"}),
+    (typing.Dict[str, int], {"type": fields.MAP, "values": fields.LONG, "name": "optional_field"}),
     (
         typing.Dict[str, datetime.datetime],
         {"type": fields.MAP, "values": fields.LOGICAL_DATETIME, "name": "optional_field"},
@@ -168,10 +168,10 @@ avro_user = {
 }
 
 ARRAY_WITH_UNION_TYPES = (
-    (typing.Union[int, str], [fields.INT, fields.STRING], [10, 20, "test"]),
+    (typing.Union[int, str], [fields.LONG, fields.STRING], [10, 20, "test"]),
     (
         typing.Union[int, str, User],
-        [fields.INT, fields.STRING, avro_user],
+        [fields.LONG, fields.STRING, avro_user],
         [10, 20, "test"],
     ),
 )

--- a/tests/schemas/avro/union_type.avsc
+++ b/tests/schemas/avro/union_type.avsc
@@ -4,7 +4,7 @@
   "fields": [
     {
       "name": "first_union",
-      "type": ["string", "int"]
+      "type": ["string", "long"]
     },
     {
       "name": "logical_union",

--- a/tests/schemas/avro/user.avsc
+++ b/tests/schemas/avro/user.avsc
@@ -3,9 +3,9 @@
   "name": "User",
   "fields": [
     {"name": "name", "type": "string"},
-    {"name": "age", "type": "int"},
+    {"name": "age", "type": "long"},
     {"name": "has_pets", "type": "boolean"},
-    {"name": "money", "type": "float"},
+    {"name": "money", "type": "double"},
     {"name": "encoded", "type": "bytes"}
   ]
 }

--- a/tests/schemas/avro/user_advance.avsc
+++ b/tests/schemas/avro/user_advance.avsc
@@ -8,7 +8,7 @@
     },
     {
       "name": "age",
-      "type": "int"
+      "type": "long"
     },
     {
       "name": "pets",
@@ -22,7 +22,7 @@
       "name": "accounts",
       "type": {
         "type": "map",
-        "values": "int",
+        "values": "long",
         "name": "account"
       }
     },

--- a/tests/schemas/avro/user_advance_with_defaults.avsc
+++ b/tests/schemas/avro/user_advance_with_defaults.avsc
@@ -8,7 +8,7 @@
       },
       {
         "name": "age",
-        "type": "int"
+        "type": "long"
       },
       {
         "name": "pets",
@@ -23,7 +23,7 @@
         "name": "accounts",
         "type": {
           "type": "map",
-          "values": "int",
+          "values": "long",
           "name": "account"
         },
         "default": {

--- a/tests/schemas/avro/user_extra_avro_attributes.avsc
+++ b/tests/schemas/avro/user_extra_avro_attributes.avsc
@@ -3,7 +3,7 @@
   "name": "User",
   "fields": [
      {"name": "name", "type": "string"},
-     {"name": "age", "type": "int"}
+     {"name": "age", "type": "long"}
   ],
   "doc": "An User",
   "namespace": "test.com.ar/user/v1",

--- a/tests/schemas/avro/user_many_address.avsc
+++ b/tests/schemas/avro/user_many_address.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "addresses",
@@ -24,7 +24,7 @@
                         },
                         {
                             "name": "street_number",
-                            "type": "int"
+                            "type": "long"
                         }
                     ],
                     "doc": "An Address"

--- a/tests/schemas/avro/user_many_address_map.avsc
+++ b/tests/schemas/avro/user_many_address_map.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "addresses",
@@ -24,7 +24,7 @@
                         },
                         {
                             "name": "street_number",
-                            "type": "int"
+                            "type": "long"
                         }
                     ],
                     "doc": "An Address"

--- a/tests/schemas/avro/user_one_address.avsc
+++ b/tests/schemas/avro/user_one_address.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "address",
@@ -22,7 +22,7 @@
                     },
                     {
                         "name": "street_number",
-                        "type": "int"
+                        "type": "long"
                     }
                 ],
                 "doc": "An Address"

--- a/tests/schemas/avro/user_one_address_with_none_default.avsc
+++ b/tests/schemas/avro/user_one_address_with_none_default.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "address",
@@ -24,7 +24,7 @@
                     },
                     {
                         "name": "street_number",
-                        "type": "int"
+                        "type": "long"
                     }
                 ],
                 "doc": "An Address"

--- a/tests/schemas/avro/user_self_reference_one_to_many.avsc
+++ b/tests/schemas/avro/user_self_reference_one_to_many.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "friends",

--- a/tests/schemas/avro/user_self_reference_one_to_many_map.avsc
+++ b/tests/schemas/avro/user_self_reference_one_to_many_map.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "friends",

--- a/tests/schemas/avro/user_self_reference_one_to_one.avsc
+++ b/tests/schemas/avro/user_self_reference_one_to_one.avsc
@@ -8,7 +8,7 @@
         },
         {
             "name": "age",
-            "type": "int"
+            "type": "long"
         },
         {
             "name": "friend",

--- a/tests/schemas/avro/user_v2.avsc
+++ b/tests/schemas/avro/user_v2.avsc
@@ -3,7 +3,7 @@
   "name": "UserV2",
   "fields": [
     {"name": "name", "type": "string"},
-    {"name": "age", "type": "int"}   
+    {"name": "age", "type": "long"}   
   ],
   "doc": "A User V2"
 }

--- a/tests/schemas/avro/user_with_field_metadata.avsc
+++ b/tests/schemas/avro/user_with_field_metadata.avsc
@@ -3,9 +3,9 @@
   "name": "User",
   "fields": [
     {"name": "name", "type": "string", "classification":  "test"},
-    {"name": "age", "type": "int", "classification":  "test"},
+    {"name": "age", "type": "long", "classification":  "test"},
     {"name": "has_pets", "type": "boolean", "classification":  "test"},
-    {"name": "money", "type": "float", "classification":  "test"},
+    {"name": "money", "type": "double", "classification":  "test"},
     {"name": "encoded", "type": "bytes", "classification":  "test"}
   ]
 }


### PR DESCRIPTION
... and Avro type for Python float to double.

Reasoning:

 - "Integers have unlimited precision." [[1]](https://docs.python.org/3.4/library/stdtypes.html#typesnumeric)
 - "Floating point numbers are usually implemented using double in C;" [[1]](https://docs.python.org/3.4/library/stdtypes.html#typesnumeric) and "almost all platforms map Python floats to IEEE-754 “double precision”." [[2]](https://docs.python.org/3/tutorial/floatingpoint.html#representation-error)