### PR TITLE
Add support for decimal logical type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ coverage
 
 # Workspace files are user-specific
 *.sublime-workspace
+# Removes PyCharm/JetBrains workspace files
+.idea/
 
 # Project files should be checked into the repository, unless a significant
 # proportion of contributors will probably not be using Sublime Text

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -813,7 +813,7 @@ def field_factory(
             default_factory=default_factory,
         )
     elif native_type in PYTHON_LOGICAL_TYPES:
-        klass = LOGICAL_TYPES_FIELDS_CLASSES[native_type]
+        klass = LOGICAL_TYPES_FIELDS_CLASSES[native_type]  # type: ignore
         return klass(name=name, type=native_type, default=default, metadata=metadata)
     else:
         return RecordField(name=name, type=native_type, default=default, metadata=metadata)

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -13,7 +13,7 @@ import inflect
 from faker import Faker
 from pytz import utc
 
-from dataclasses_avroschema import types, utils
+from dataclasses_avroschema import types, utils, serialization
 
 fake = Faker()
 p = inflect.engine()
@@ -701,8 +701,7 @@ class DecimalField(BaseField):
         if default == types.MissingSentinel:
             return dataclasses.MISSING
         else:
-            def_bytes = utils.prepare_bytes_decimal(default, self.precision, self.scale)
-            return def_bytes.decode()
+            return serialization.decimal_to_str(default, self.precision, self.scale)
 
     def fake(self):
         self.set_precision_scale()

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -13,7 +13,7 @@ import inflect
 from faker import Faker
 from pytz import utc
 
-from dataclasses_avroschema import types, utils, serialization
+from dataclasses_avroschema import serialization, types, utils
 
 fake = Faker()
 p = inflect.engine()
@@ -63,22 +63,25 @@ PYTHON_INMUTABLE_TYPES = (str, int, bool, float, bytes, type(None))
 
 PYTHON_PRIMITIVE_CONTAINERS = (list, tuple, dict)
 
-PYTHON_LOGICAL_TYPES = (
-    datetime.date,
-    datetime.time,
-    datetime.datetime,
-    uuid.uuid4,
-    uuid.UUID,
-    decimal.Decimal
-)
+PYTHON_LOGICAL_TYPES = (datetime.date, datetime.time, datetime.datetime, uuid.uuid4, uuid.UUID, decimal.Decimal)
 
 PYTHON_PRIMITIVE_TYPES = PYTHON_INMUTABLE_TYPES + PYTHON_PRIMITIVE_CONTAINERS
 
 PRIMITIVE_AND_LOGICAL_TYPES = PYTHON_INMUTABLE_TYPES + PYTHON_LOGICAL_TYPES
 
 PythonImnutableTypes = typing.Union[
-    str, int, bool, float, list, tuple, dict, datetime.date, datetime.time, datetime.datetime, uuid.UUID
-    , decimal.Decimal
+    str,
+    int,
+    bool,
+    float,
+    list,
+    tuple,
+    dict,
+    datetime.date,
+    datetime.time,
+    datetime.datetime,
+    uuid.UUID,
+    decimal.Decimal,
 ]
 
 
@@ -645,11 +648,11 @@ class RecordField(BaseField):
 @dataclasses.dataclass
 class DecimalField(BaseField):
 
-    precision: int = None
+    precision: int = -1
     scale: int = 0
     has_set_prec_scale = False
 
-    def set_precision_scale(self):
+    def set_precision_scale(self) -> None:
         if self.has_set_prec_scale:
             return
         self.has_set_prec_scale = True
@@ -673,8 +676,10 @@ class DecimalField(BaseField):
             else:
                 raise ValueError("decimal.Decimal default types must be either decimal.Decimal or types.Decimal")
         else:
-            raise ValueError("decimal.Decimal default types must be specified to provide precision and scale,"
-                             " and must be either decimal.Decimal or types.Decimal")
+            raise ValueError(
+                "decimal.Decimal default types must be specified to provide precision and scale,"
+                " and must be either decimal.Decimal or types.Decimal"
+            )
 
             # Just pull the precision from default context and default out scale
             # Not ideal
@@ -683,16 +688,11 @@ class DecimalField(BaseField):
 
     def get_avro_type(self) -> typing.Dict[str, typing.Any]:
         self.set_precision_scale()
-        avro_type = {
-                "type": BYTES,
-                "logicalType": DECIMAL,
-                "precision": self.precision,
-                "scale": self.scale
-            }
+        avro_type = {"type": BYTES, "logicalType": DECIMAL, "precision": self.precision, "scale": self.scale}
 
         return avro_type
 
-    def get_default_value(self):
+    def get_default_value(self) -> typing.Union[str, dataclasses._MISSING_TYPE, None]:
         self.set_precision_scale()
         default = self.default
         if isinstance(default, types.Decimal):
@@ -703,9 +703,9 @@ class DecimalField(BaseField):
         else:
             return serialization.decimal_to_str(default, self.precision, self.scale)
 
-    def fake(self):
+    def fake(self) -> decimal.Decimal:
         self.set_precision_scale()
-        return fake.pydecimal(right_digits=self.scale, left_digits=self.precision-self.scale)
+        return fake.pydecimal(right_digits=self.scale, left_digits=self.precision - self.scale)
 
 
 INMUTABLE_FIELDS_CLASSES = {
@@ -714,7 +714,7 @@ INMUTABLE_FIELDS_CLASSES = {
     float: DoubleField,
     bytes: BytesField,
     str: StringField,
-    type(None): NoneField
+    type(None): NoneField,
 }
 
 CONTAINER_FIELDS_CLASSES = {
@@ -735,7 +735,7 @@ LOGICAL_TYPES_FIELDS_CLASSES = {
     uuid.uuid4: UUIDField,
     uuid.UUID: UUIDField,
     bytes: BytesField,
-    decimal.Decimal: DecimalField
+    decimal.Decimal: DecimalField,
 }
 
 PRIMITIVE_LOGICAL_TYPES_FIELDS_CLASSES = {

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -109,7 +109,7 @@ def to_json(data: typing.Dict[str, typing.Any]) -> typing.Dict:
             value = date_to_str(value)
         elif isinstance(value, datetime.time):
             value = time_to_str(value)
-        elif isinstance(value, uuid.UUID) or isinstance(value, decimal.Decimal):
+        elif isinstance(value, (uuid.UUID, decimal.Decimal)):
             value = str(value)
 
         json_data[field] = value

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -73,11 +73,6 @@ def decimal_to_str(value: decimal.Decimal, precision: int, scale: int = 0) -> st
 def prepare_bytes_decimal(data: decimal.Decimal, precision: int, scale: int = 0) -> bytes:
     """Convert decimal.Decimal to bytes"""
 
-    if not isinstance(data, decimal.Decimal):
-        raise ValueError(
-            "Object type different from decimal.Decimal was passed into serialization.prepare_bytes_decimal"
-        )
-
     sign, digits, exp = data.as_tuple()
 
     if len(digits) > precision:

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -2,7 +2,7 @@ import datetime
 import io
 import typing
 import uuid
-
+import decimal
 import fastavro
 
 DATETIME_STR_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
@@ -61,6 +61,45 @@ def time_to_str(value: datetime.time) -> str:
     return value.strftime(TIME_STR_FORMAT)
 
 
+def decimal_to_str(value: decimal.Decimal, precision: int, scale: int = 0) -> str:
+    value_bytes = prepare_bytes_decimal(value, precision, scale)
+    return r'\u' + value_bytes.hex()
+
+# This is an almost complete copy of fastavro's _logical_writers_py.prepare_bytes_decimal
+# the only tweak is to pass in scale/precision directly instead of a schema
+# This is needed to properly serialize a default decimal.Decimal into the avro schema
+def prepare_bytes_decimal(data, precision, scale=0):
+    """Convert decimal.Decimal to bytes"""
+
+    if not isinstance(data, decimal.Decimal):
+        return data
+
+    sign, digits, exp = data.as_tuple()
+
+    if len(digits) > precision:
+        raise ValueError(
+            'The decimal precision is bigger than allowed by schema')
+
+    delta = exp + scale
+
+    if delta < 0:
+        raise ValueError(
+            'Scale provided in schema does not match the decimal')
+
+    unscaled_datum = 0
+    for digit in digits:
+        unscaled_datum = (unscaled_datum * 10) + digit
+
+    unscaled_datum = 10 ** delta * unscaled_datum
+
+    bytes_req = (unscaled_datum.bit_length() + 8) // 8
+
+    if sign:
+        unscaled_datum = -unscaled_datum
+
+    return unscaled_datum.to_bytes(bytes_req, byteorder='big', signed=True)
+
+
 def to_json(data: typing.Dict[str, typing.Any]) -> typing.Dict:
     json_data = {}
 
@@ -73,7 +112,7 @@ def to_json(data: typing.Dict[str, typing.Any]) -> typing.Dict:
             value = date_to_str(value)
         elif isinstance(value, datetime.time):
             value = time_to_str(value)
-        elif isinstance(value, uuid.UUID):
+        elif isinstance(value, uuid.UUID) or isinstance(value, decimal.Decimal):
             value = str(value)
 
         json_data[field] = value

--- a/dataclasses_avroschema/types.py
+++ b/dataclasses_avroschema/types.py
@@ -48,5 +48,24 @@ class Enum(typing.Generic[T]):
     def __repr__(self) -> str:
         return f"{self.symbols}"
 
+@dataclasses.dataclass
+class Decimal(typing.Generic[T]):
+    """
+    Represents an Avro Decimal type
 
-CUSTOM_TYPES = ("Fixed", "Enum")
+    precision (int): Specifying the number precision
+    scale(int): Specifying the number scale. Default 0
+    """
+    precision: int
+    scale: int = 0
+    default: typing.Any = dataclasses.field(default=MissingSentinel)
+    _dataclasses_custom_type: str = "Decimal"
+
+    # Decimal serializes to bytes, which doesn't support namespace
+    aliases: typing.Optional[typing.List] = None
+
+    def __repr__(self) -> str:
+        return f"Decimal precision: {self.precision} scale:{self.scale}"
+
+
+CUSTOM_TYPES = ("Fixed", "Enum", "Decimal")

--- a/dataclasses_avroschema/types.py
+++ b/dataclasses_avroschema/types.py
@@ -48,6 +48,7 @@ class Enum(typing.Generic[T]):
     def __repr__(self) -> str:
         return f"{self.symbols}"
 
+
 @dataclasses.dataclass
 class Decimal(typing.Generic[T]):
     """
@@ -56,6 +57,7 @@ class Decimal(typing.Generic[T]):
     precision (int): Specifying the number precision
     scale(int): Specifying the number scale. Default 0
     """
+
     precision: int
     scale: int = 0
     default: typing.Any = dataclasses.field(default=MissingSentinel)

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -1,7 +1,7 @@
 import typing
 from dataclasses import dataclass
 from datetime import datetime
-import decimal
+
 from pytz import utc
 
 from .types import CUSTOM_TYPES

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -1,7 +1,7 @@
 import typing
 from dataclasses import dataclass
 from datetime import datetime
-
+import decimal
 from pytz import utc
 
 from .types import CUSTOM_TYPES
@@ -49,6 +49,40 @@ def is_custom_type(value: typing.Any) -> bool:
     """
     return isinstance(value, dict) and value.get("_dataclasses_custom_type") in CUSTOM_TYPES
 
+
+# This is an almost complete copy of fastavro's _logical_writers_py.prepare_bytes_decimal
+# the only tweak is to pass in scale/precision directly instead of a schema
+def prepare_bytes_decimal(data, precision, scale=0):
+    """Convert decimal.Decimal to bytes"""
+    # print(data, precision, scale)
+
+    if not isinstance(data, decimal.Decimal):
+        return data
+
+    sign, digits, exp = data.as_tuple()
+
+    if len(digits) > precision:
+        raise ValueError(
+            'The decimal precision is bigger than allowed by schema')
+
+    delta = exp + scale
+
+    if delta < 0:
+        raise ValueError(
+            'Scale provided in schema does not match the decimal')
+
+    unscaled_datum = 0
+    for digit in digits:
+        unscaled_datum = (unscaled_datum * 10) + digit
+
+    unscaled_datum = 10 ** delta * unscaled_datum
+
+    bytes_req = (unscaled_datum.bit_length() + 8) // 8
+
+    if sign:
+        unscaled_datum = -unscaled_datum
+
+    return unscaled_datum.to_bytes(bytes_req, byteorder='big', signed=True)
 
 @dataclass
 class SchemaMetadata:

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -52,9 +52,9 @@ def is_custom_type(value: typing.Any) -> bool:
 
 # This is an almost complete copy of fastavro's _logical_writers_py.prepare_bytes_decimal
 # the only tweak is to pass in scale/precision directly instead of a schema
+# This is needed to properly serialize a default decimal.Decimal into the avro schema
 def prepare_bytes_decimal(data, precision, scale=0):
     """Convert decimal.Decimal to bytes"""
-    # print(data, precision, scale)
 
     if not isinstance(data, decimal.Decimal):
         return data

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -50,40 +50,6 @@ def is_custom_type(value: typing.Any) -> bool:
     return isinstance(value, dict) and value.get("_dataclasses_custom_type") in CUSTOM_TYPES
 
 
-# This is an almost complete copy of fastavro's _logical_writers_py.prepare_bytes_decimal
-# the only tweak is to pass in scale/precision directly instead of a schema
-# This is needed to properly serialize a default decimal.Decimal into the avro schema
-def prepare_bytes_decimal(data, precision, scale=0):
-    """Convert decimal.Decimal to bytes"""
-
-    if not isinstance(data, decimal.Decimal):
-        return data
-
-    sign, digits, exp = data.as_tuple()
-
-    if len(digits) > precision:
-        raise ValueError(
-            'The decimal precision is bigger than allowed by schema')
-
-    delta = exp + scale
-
-    if delta < 0:
-        raise ValueError(
-            'Scale provided in schema does not match the decimal')
-
-    unscaled_datum = 0
-    for digit in digits:
-        unscaled_datum = (unscaled_datum * 10) + digit
-
-    unscaled_datum = 10 ** delta * unscaled_datum
-
-    bytes_req = (unscaled_datum.bit_length() + 8) // 8
-
-    if sign:
-        unscaled_datum = -unscaled_datum
-
-    return unscaled_datum.to_bytes(bytes_req, byteorder='big', signed=True)
-
 @dataclass
 class SchemaMetadata:
     schema_doc: bool = True

--- a/docs/fields_specification.md
+++ b/docs/fields_specification.md
@@ -81,6 +81,8 @@ Language implementations must ignore unknown logical types when reading, and sho
 
 * UUID: Represents a uuid as a string
 
+* Decimal: Represents a decimal.Decimal as bytes
+
 | Avro Type | Logical Type |Python Type |
 |-----------|--------------|-------------|
 | int       |  date        | datetime.date
@@ -88,6 +90,7 @@ Language implementations must ignore unknown logical types when reading, and sho
 | long      |  timestamp-millis | datetime.datetime |
 | string    |  uuid        | uuid.uuid4 |
 | string    |  uuid        | uuid.UUID |
+| bytes     | decimal      | decimal.Decimal |
 
 ### Avro Field and Python Types Summary
 
@@ -115,6 +118,7 @@ Python Type | Avro Type   | Logical Type |
 | datetime.time | int     |  time-millis |
 | datetime.datetim| long  |  timestamp-millis |
 | uuid.uuid4  | string    |  uuid        |
+| decimal.Decimal | bytes | decimal      |
 
 ## Adding Custom Field-level Attributes
 

--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -2,8 +2,9 @@ import dataclasses
 import datetime
 import typing
 import uuid
+import decimal
 
-from dataclasses_avroschema import AvroModel
+from dataclasses_avroschema import AvroModel, types
 
 
 def test_fake_primitive_types(user_dataclass):
@@ -129,5 +130,18 @@ def test_self_one_to_many_map_relationship():
         age: int
         friends: typing.Dict[str, typing.Type["User"]]
         teamates: typing.Dict[str, typing.Type["User"]] = None
+
+    assert isinstance(User.fake(), User)
+
+
+def test_decimals():
+    """
+    Test Decimal logical types
+    """
+    class User(AvroModel):
+        name: str
+        age: int
+        test_score_1: decimal.Decimal = decimal.Decimal('100.00')
+        test_score_2: decimal.Decimal = types.Decimal(scale=5, precision=11)
 
     assert isinstance(User.fake(), User)

--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -1,8 +1,8 @@
 import dataclasses
 import datetime
+import decimal
 import typing
 import uuid
-import decimal
 
 from dataclasses_avroschema import AvroModel, types
 
@@ -138,10 +138,11 @@ def test_decimals():
     """
     Test Decimal logical types
     """
+
     class User(AvroModel):
         name: str
         age: int
-        test_score_1: decimal.Decimal = decimal.Decimal('100.00')
+        test_score_1: decimal.Decimal = decimal.Decimal("100.00")
         test_score_2: decimal.Decimal = types.Decimal(scale=5, precision=11)
 
     assert isinstance(User.fake(), User)

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -176,24 +176,40 @@ def test_decimal_type():
   }
 
     assert expected == field.to_dict()
+    # Just making sure a double-internal-call to set_precision_scale doesn't break things and is hit for coverage
+    assert expected == field.to_dict()
 
     # If default is missing, default out scale by Avro spec and pull precision from default decimal context
     # On my machine, this makes the "decimal" field a glorified 28-digit int, which is likely not what is wanted
     # so there is a good argument to error this out and force the dev to provide a default
-    default = types.MissingSentinel
-    field = fields.AvroField(name, python_type, default)
+    # default = types.MissingSentinel
+    # field = fields.AvroField(name, python_type, default)
+    #
+    # expected = {
+    #     "name": name,
+    #     "type": {
+    #         "type": "bytes",
+    #         "logicalType": "decimal",
+    #         "precision": decimal.Context().prec,
+    #         "scale": 0,
+    #     },
+    # }
+    #
+    # assert expected == field.to_dict()
 
-    expected = {
-        "name": name,
-        "type": {
-            "type": "bytes",
-            "logicalType": "decimal",
-            "precision": decimal.Context().prec,
-            "scale": 0,
-        },
-    }
+    # Require a default be provided for decimal.Decimal
+    with pytest.raises(ValueError):
+        default = types.MissingSentinel
+        field = fields.AvroField(name, python_type, default)
 
-    assert expected == field.to_dict()
+        field.to_dict()
+
+    # Catch unexpected default value for decimal.Decimal
+    with pytest.raises(ValueError):
+        default = 7
+        field = fields.AvroField(name, python_type, default)
+
+        field.to_dict()
 
     # Default decimal.Decimal has more digits than listed precision
     with pytest.raises(ValueError):

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -1,10 +1,11 @@
 import datetime
-import uuid
 import decimal
+import uuid
+from dataclasses import field
+
 import pytest
 
 from dataclasses_avroschema import fields, types
-from dataclasses import field
 
 from . import consts
 
@@ -121,6 +122,7 @@ def test_invalid_default_values(logical_type, invalid_default, msg):
     with pytest.raises(AssertionError, match=msg):
         field.to_dict()
 
+
 def test_decimal_type():
     """
     When the type is types.Decimal, the Avro field type should be bytes,
@@ -128,7 +130,7 @@ def test_decimal_type():
     """
     name = "a_decimal_field"
     # A default decimal.Decimal sets precision and scale implicitly
-    default = decimal.Decimal('3.14')
+    default = decimal.Decimal("3.14")
     python_type = decimal.Decimal
     field = fields.AvroField(name, python_type, default)
 
@@ -140,7 +142,7 @@ def test_decimal_type():
             "precision": 3,
             "scale": 2,
         },
-        "default": '\\u013a',
+        "default": "\\u013a",
     }
 
     assert expected == field.to_dict()
@@ -161,7 +163,7 @@ def test_decimal_type():
 
     assert expected == field.to_dict()
 
-    default = types.Decimal(scale=5, precision=7, default=decimal.Decimal('3.14'))
+    default = types.Decimal(scale=5, precision=7, default=decimal.Decimal("3.14"))
     field = fields.AvroField(name, python_type, default)
 
     expected = {
@@ -172,8 +174,8 @@ def test_decimal_type():
             "precision": 7,
             "scale": 5,
         },
-        "default": '\\u04ca90',
-  }
+        "default": "\\u04ca90",
+    }
 
     assert expected == field.to_dict()
     # Just making sure a double-internal-call to set_precision_scale doesn't break things and is hit for coverage
@@ -213,14 +215,14 @@ def test_decimal_type():
 
     # Default decimal.Decimal has more digits than listed precision
     with pytest.raises(ValueError):
-        default = types.Decimal(scale=2, precision=3, default=decimal.Decimal('3.14159'))
+        default = types.Decimal(scale=2, precision=3, default=decimal.Decimal("3.14159"))
         field = fields.AvroField(name, python_type, default)
 
         field.to_dict()
 
     # Default decimal.Decimal has more digits past decimal than scale
     with pytest.raises(ValueError):
-        default = types.Decimal(scale=1, precision=3, default=decimal.Decimal('3.14'))
+        default = types.Decimal(scale=1, precision=3, default=decimal.Decimal("3.14"))
         field = fields.AvroField(name, python_type, default)
 
         field.to_dict()

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -140,7 +140,7 @@ def test_decimal_type():
             "precision": 3,
             "scale": 2,
         },
-        "default": '\x01:',
+        "default": '\\u013a',
     }
 
     assert expected == field.to_dict()
@@ -172,7 +172,7 @@ def test_decimal_type():
             "precision": 7,
             "scale": 5,
         },
-        "default": '\x04ʐ',
+        "default": '\\u04ca90',
   }
 
     assert expected == field.to_dict()

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -1,9 +1,10 @@
 import datetime
 import uuid
-
+import decimal
 import pytest
 
-from dataclasses_avroschema import fields
+from dataclasses_avroschema import fields, types
+from dataclasses import field
 
 from . import consts
 
@@ -118,4 +119,92 @@ def test_invalid_default_values(logical_type, invalid_default, msg):
 
     msg = msg or f"Invalid default type. Default should be {logical_type}"
     with pytest.raises(AssertionError, match=msg):
+        field.to_dict()
+
+def test_decimal_type():
+    """
+    When the type is types.Decimal, the Avro field type should be bytes,
+    with logicalType=decimal and metadata attributes scale, precision present as ints
+    """
+    name = "a_decimal_field"
+    # A default decimal.Decimal sets precision and scale implicitly
+    default = decimal.Decimal('3.14')
+    python_type = decimal.Decimal
+    field = fields.AvroField(name, python_type, default)
+
+    expected = {
+        "name": name,
+        "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 3,
+            "scale": 2,
+        },
+        "default": '\x01:',
+    }
+
+    assert expected == field.to_dict()
+
+    # Use types.Decimal to set explicitly
+    default = types.Decimal(scale=5, precision=7)
+    field = fields.AvroField(name, python_type, default)
+
+    expected = {
+        "name": name,
+        "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 7,
+            "scale": 5,
+        },
+    }
+
+    assert expected == field.to_dict()
+
+    default = types.Decimal(scale=5, precision=7, default=decimal.Decimal('3.14'))
+    field = fields.AvroField(name, python_type, default)
+
+    expected = {
+        "name": name,
+        "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": 7,
+            "scale": 5,
+        },
+        "default": '\x04ʐ',
+  }
+
+    assert expected == field.to_dict()
+
+    # If default is missing, default out scale by Avro spec and pull precision from default decimal context
+    # On my machine, this makes the "decimal" field a glorified 28-digit int, which is likely not what is wanted
+    # so there is a good argument to error this out and force the dev to provide a default
+    default = types.MissingSentinel
+    field = fields.AvroField(name, python_type, default)
+
+    expected = {
+        "name": name,
+        "type": {
+            "type": "bytes",
+            "logicalType": "decimal",
+            "precision": decimal.Context().prec,
+            "scale": 0,
+        },
+    }
+
+    assert expected == field.to_dict()
+
+    # Default decimal.Decimal has more digits than listed precision
+    with pytest.raises(ValueError):
+        default = types.Decimal(scale=2, precision=3, default=decimal.Decimal('3.14159'))
+        field = fields.AvroField(name, python_type, default)
+
+        field.to_dict()
+
+    # Default decimal.Decimal has more digits past decimal than scale
+    with pytest.raises(ValueError):
+        default = types.Decimal(scale=1, precision=3, default=decimal.Decimal('3.14'))
+        field = fields.AvroField(name, python_type, default)
+
         field.to_dict()

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -226,3 +226,10 @@ def test_decimal_type():
         field = fields.AvroField(name, python_type, default)
 
         field.to_dict()
+
+    # Just for code coverage
+    with pytest.raises(ValueError):
+        default = types.Decimal(scale=1, precision=3, default=decimal.Decimal("3.14"))
+        field = fields.AvroField(name, python_type, default)
+
+        field.to_dict()

--- a/tests/schemas/avro/decimal.avsc
+++ b/tests/schemas/avro/decimal.avsc
@@ -3,13 +3,33 @@
   "name": "DecimalTest",
   "fields": [
     {
-      "name": "decimal_types_default",
+      "name": "implicit",
       "type": {
         "type": "bytes",
         "logicalType": "decimal",
         "precision": 3,
         "scale": 2
+      },
+      "default": "\\u013a"
+    },
+    {
+      "name": "explicit",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 13,
+        "scale": 11
       }
+    },
+    {
+      "name": "explicit_with_default",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 7,
+        "scale": 5
+      },
+      "default": "\\u04cb2f"
     }
   ],
   "doc": "Some Decimal Tests"

--- a/tests/schemas/avro/decimal.avsc
+++ b/tests/schemas/avro/decimal.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "DecimalTest",
+  "fields": [
+    {
+      "name": "decimal_types_default",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 3,
+        "scale": 2
+      }
+    }
+  ],
+  "doc": "Some Decimal Tests"
+}

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -90,3 +90,8 @@ def logical_types_schema():
 @pytest.fixture
 def union_type_schema():
     return load_json("union_type.avsc")
+
+
+@pytest.fixture
+def decimal_types_schema():
+    return load_json("decimal.avsc")

--- a/tests/schemas/test_schema_with_logical_types.py
+++ b/tests/schemas/test_schema_with_logical_types.py
@@ -1,8 +1,11 @@
 import datetime
 import json
 import uuid
+import decimal
 
-from dataclasses_avroschema import AvroModel
+from dataclasses_avroschema import AvroModel, types
+from dataclasses import field
+
 
 
 def test_logical_types_schema(logical_types_schema):
@@ -19,3 +22,22 @@ def test_logical_types_schema(logical_types_schema):
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert LogicalTypes.avro_schema() == json.dumps(logical_types_schema)
+
+
+# def test_decimal_types_schema(decimal_types_schema):
+#     """
+#     Test a schema with decimal types
+#     """
+#
+#     class DecimalTest(AvroModel):
+#         "Some Decimal Tests"
+#         # Implicit scale and precision
+#         decimal_nodefault: decimal.Decimal  # Error out? Pull precision from context and default scale?
+#         decimal_decimal_default: decimal.Decimal = decimal.Decimal('3.14')  # Precision from context, scale from .as_tuple
+#
+#         # Explicit scale and precision
+#         # decimal_default_typed: decimal.Decimal = field(scale=2, precision=3)
+#
+#     print(DecimalTest.avro_schema())
+#
+#     assert DecimalTest.avro_schema() == json.dumps(decimal_types_schema)

--- a/tests/schemas/test_schema_with_logical_types.py
+++ b/tests/schemas/test_schema_with_logical_types.py
@@ -1,11 +1,10 @@
 import datetime
+import decimal
 import json
 import uuid
-import decimal
-
-from dataclasses_avroschema import AvroModel, types
 from dataclasses import field
 
+from dataclasses_avroschema import AvroModel, types
 
 
 def test_logical_types_schema(logical_types_schema):
@@ -31,8 +30,8 @@ def test_decimal_types_schema(decimal_types_schema):
 
     class DecimalTest(AvroModel):
         "Some Decimal Tests"
-        implicit: decimal.Decimal = decimal.Decimal('3.14')
+        implicit: decimal.Decimal = decimal.Decimal("3.14")
         explicit: decimal.Decimal = types.Decimal(scale=11, precision=13)
-        explicit_with_default: decimal.Decimal = types.Decimal(scale=5, precision=7, default=decimal.Decimal('3.14159'))
+        explicit_with_default: decimal.Decimal = types.Decimal(scale=5, precision=7, default=decimal.Decimal("3.14159"))
 
     assert DecimalTest.avro_schema() == json.dumps(decimal_types_schema)

--- a/tests/schemas/test_schema_with_logical_types.py
+++ b/tests/schemas/test_schema_with_logical_types.py
@@ -24,20 +24,15 @@ def test_logical_types_schema(logical_types_schema):
     assert LogicalTypes.avro_schema() == json.dumps(logical_types_schema)
 
 
-# def test_decimal_types_schema(decimal_types_schema):
-#     """
-#     Test a schema with decimal types
-#     """
-#
-#     class DecimalTest(AvroModel):
-#         "Some Decimal Tests"
-#         # Implicit scale and precision
-#         decimal_nodefault: decimal.Decimal  # Error out? Pull precision from context and default scale?
-#         decimal_decimal_default: decimal.Decimal = decimal.Decimal('3.14')  # Precision from context, scale from .as_tuple
-#
-#         # Explicit scale and precision
-#         # decimal_default_typed: decimal.Decimal = field(scale=2, precision=3)
-#
-#     print(DecimalTest.avro_schema())
-#
-#     assert DecimalTest.avro_schema() == json.dumps(decimal_types_schema)
+def test_decimal_types_schema(decimal_types_schema):
+    """
+    Test a schema with decimal types
+    """
+
+    class DecimalTest(AvroModel):
+        "Some Decimal Tests"
+        implicit: decimal.Decimal = decimal.Decimal('3.14')
+        explicit: decimal.Decimal = types.Decimal(scale=11, precision=13)
+        explicit_with_default: decimal.Decimal = types.Decimal(scale=5, precision=7, default=decimal.Decimal('3.14159'))
+
+    assert DecimalTest.avro_schema() == json.dumps(decimal_types_schema)

--- a/tests/serialization/test_logical_types_serialization.py
+++ b/tests/serialization/test_logical_types_serialization.py
@@ -1,10 +1,11 @@
 import datetime
 import uuid
 from dataclasses import dataclass
-
+import decimal
 import pytz
 
-from dataclasses_avroschema import AvroModel, serialization
+from dataclasses_avroschema import AvroModel, serialization, types
+
 
 a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
 a_datetime = pytz.utc.localize(a_datetime)
@@ -55,12 +56,18 @@ def test_logical_types_with_defaults():
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
+        implicit_decimal: decimal.Decimal = decimal.Decimal('3.14')
+        explicit_decimal: decimal.Decimal = types.Decimal(scale=5, precision=7)
+        explicit_decimal_with_default: decimal.Decimal = types.Decimal(scale=5, precision=6, default=decimal.Decimal('3.14159'))
 
     data = {
         "birthday": a_datetime.date(),
         "meeting_time": a_datetime.time(),
         "release_datetime": a_datetime,
         "event_uuid": uuid.UUID("09f00184-7721-4266-a955-21048a5cc235"),
+        "implicit_decimal": decimal.Decimal('2.72'),
+        "explicit_decimal": decimal.Decimal('1.00'),
+        "explicit_decimal_with_default": decimal.Decimal('3.14159')
     }
 
     data_json = {
@@ -68,6 +75,9 @@ def test_logical_types_with_defaults():
         "meeting_time": serialization.time_to_str(a_datetime.time()),
         "release_datetime": serialization.datetime_to_str(a_datetime),
         "event_uuid": "09f00184-7721-4266-a955-21048a5cc235",
+        "implicit_decimal": "2.72",
+        "explicit_decimal": "1.00",
+        "explicit_decimal_with_default": "3.14159"
     }
 
     logical_types = LogicalTypes(**data)
@@ -80,5 +90,37 @@ def test_logical_types_with_defaults():
 
     assert logical_types.deserialize(avro_binary) == logical_types
     assert logical_types.deserialize(avro_json, serialization_type="avro-json") == logical_types
+
+    assert logical_types.to_json() == data_json
+
+
+# A decimal.Decimal default is serialized into bytes by dataclasses-avroschema to be deserialized by fastavro
+# this test is to make sure that process works as expected
+def test_decimals_defaults():
+    @dataclass
+    class LogicalTypes(AvroModel):
+        "Some logical types"
+        implicit_decimal: decimal.Decimal = decimal.Decimal('3.14')
+        explicit_decimal_with_default: decimal.Decimal = types.Decimal(scale=5, precision=6, default=decimal.Decimal('3.14159'))
+
+    data = {
+        "implicit_decimal": decimal.Decimal('3.14'),
+        "explicit_decimal_with_default": decimal.Decimal('3.14159')
+    }
+
+    data_json = {
+        "implicit_decimal": "3.14",
+        "explicit_decimal_with_default": "3.14159"
+    }
+
+    logical_types = LogicalTypes()
+
+    # Serialize out to capture the defaults
+    avro_binary = logical_types.serialize()
+    avro_json = logical_types.serialize(serialization_type="avro-json")
+
+    # Deserialize and compare to expected defaults
+    assert logical_types.deserialize(avro_binary, create_instance=False) == data
+    assert logical_types.deserialize(avro_json, serialization_type="avro-json", create_instance=False) == data
 
     assert logical_types.to_json() == data_json

--- a/tests/serialization/test_logical_types_serialization.py
+++ b/tests/serialization/test_logical_types_serialization.py
@@ -106,10 +106,15 @@ def test_decimals_defaults():
         explicit_decimal_with_default: decimal.Decimal = types.Decimal(
             scale=5, precision=6, default=decimal.Decimal("3.14159")
         )
+        negative_default: decimal.Decimal = types.Decimal(scale=2, precision=3, default=decimal.Decimal("-1.23"))
 
-    data = {"implicit_decimal": decimal.Decimal("3.14"), "explicit_decimal_with_default": decimal.Decimal("3.14159")}
+    data = {
+        "implicit_decimal": decimal.Decimal("3.14"),
+        "explicit_decimal_with_default": decimal.Decimal("3.14159"),
+        "negative_default": decimal.Decimal("-1.23"),
+    }
 
-    data_json = {"implicit_decimal": "3.14", "explicit_decimal_with_default": "3.14159"}
+    data_json = {"implicit_decimal": "3.14", "explicit_decimal_with_default": "3.14159", "negative_default": "-1.23"}
 
     logical_types = LogicalTypes()
 

--- a/tests/serialization/test_logical_types_serialization.py
+++ b/tests/serialization/test_logical_types_serialization.py
@@ -1,11 +1,11 @@
 import datetime
+import decimal
 import uuid
 from dataclasses import dataclass
-import decimal
+
 import pytz
 
 from dataclasses_avroschema import AvroModel, serialization, types
-
 
 a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
 a_datetime = pytz.utc.localize(a_datetime)
@@ -56,18 +56,20 @@ def test_logical_types_with_defaults():
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
-        implicit_decimal: decimal.Decimal = decimal.Decimal('3.14')
+        implicit_decimal: decimal.Decimal = decimal.Decimal("3.14")
         explicit_decimal: decimal.Decimal = types.Decimal(scale=5, precision=7)
-        explicit_decimal_with_default: decimal.Decimal = types.Decimal(scale=5, precision=6, default=decimal.Decimal('3.14159'))
+        explicit_decimal_with_default: decimal.Decimal = types.Decimal(
+            scale=5, precision=6, default=decimal.Decimal("3.14159")
+        )
 
     data = {
         "birthday": a_datetime.date(),
         "meeting_time": a_datetime.time(),
         "release_datetime": a_datetime,
         "event_uuid": uuid.UUID("09f00184-7721-4266-a955-21048a5cc235"),
-        "implicit_decimal": decimal.Decimal('2.72'),
-        "explicit_decimal": decimal.Decimal('1.00'),
-        "explicit_decimal_with_default": decimal.Decimal('3.14159')
+        "implicit_decimal": decimal.Decimal("2.72"),
+        "explicit_decimal": decimal.Decimal("1.00"),
+        "explicit_decimal_with_default": decimal.Decimal("3.14159"),
     }
 
     data_json = {
@@ -77,7 +79,7 @@ def test_logical_types_with_defaults():
         "event_uuid": "09f00184-7721-4266-a955-21048a5cc235",
         "implicit_decimal": "2.72",
         "explicit_decimal": "1.00",
-        "explicit_decimal_with_default": "3.14159"
+        "explicit_decimal_with_default": "3.14159",
     }
 
     logical_types = LogicalTypes(**data)
@@ -100,18 +102,14 @@ def test_decimals_defaults():
     @dataclass
     class LogicalTypes(AvroModel):
         "Some logical types"
-        implicit_decimal: decimal.Decimal = decimal.Decimal('3.14')
-        explicit_decimal_with_default: decimal.Decimal = types.Decimal(scale=5, precision=6, default=decimal.Decimal('3.14159'))
+        implicit_decimal: decimal.Decimal = decimal.Decimal("3.14")
+        explicit_decimal_with_default: decimal.Decimal = types.Decimal(
+            scale=5, precision=6, default=decimal.Decimal("3.14159")
+        )
 
-    data = {
-        "implicit_decimal": decimal.Decimal('3.14'),
-        "explicit_decimal_with_default": decimal.Decimal('3.14159')
-    }
+    data = {"implicit_decimal": decimal.Decimal("3.14"), "explicit_decimal_with_default": decimal.Decimal("3.14159")}
 
-    data_json = {
-        "implicit_decimal": "3.14",
-        "explicit_decimal_with_default": "3.14159"
-    }
+    data_json = {"implicit_decimal": "3.14", "explicit_decimal_with_default": "3.14159"}
 
     logical_types = LogicalTypes()
 


### PR DESCRIPTION
Added in functionality for Decimal logical data types based of Python's decimal.Decimal class, added in fields and types.
Added in types and fields definitions for Decimal. Added in tests for fields and updated documentation. decimal.Decimal types can be declared in two ways:

```
class Example(AvroModel):
   implicit: decimal.Decimal = decimal.Decimal('3.14')  # scale = 2, precision = 3, inherit from default
   explicit: decimal.Decimal = types.Decimal(scale=2, precision=3, [default=decimal.Decimal('3.14'])
```