### PR TITLE
Add `schema_name` attribute to `SchemaMetadata`. Add optional `writer_schema` in deserialization.

### DIFF
--- a/dataclasses_avroschema/schema_definition.py
+++ b/dataclasses_avroschema/schema_definition.py
@@ -30,7 +30,7 @@ class BaseSchemaDefinition(abc.ABC):
         ...  # pragma: no cover
 
     def get_schema_name(self) -> str:
-        return self.klass.__name__
+        return self.klass.metadata.schema_name or self.klass.__name__
 
     def generate_documentation(self) -> typing.Optional[str]:
         doc = self.klass.__doc__

--- a/dataclasses_avroschema/schema_generator.py
+++ b/dataclasses_avroschema/schema_generator.py
@@ -87,11 +87,22 @@ class AvroModel:
 
     @classmethod
     def deserialize(
-        cls, data: bytes, serialization_type: str = AVRO, create_instance: bool = True
+        cls,
+        data: bytes,
+        serialization_type: str = AVRO,
+        create_instance: bool = True,
+        writer_schema: typing.Optional[typing.Union[typing.Dict[str, typing.Any], "AvroModel"]] = None,
     ) -> typing.Union[typing.Dict, "AvroModel"]:
 
+        try:
+            writer_schema = writer_schema.avro_schema_to_python()
+        except AttributeError:
+            pass
+
         schema = cls.avro_schema_to_python()
-        payload = serialization.deserialize(data, schema, serialization_type=serialization_type)
+        payload = serialization.deserialize(
+            data, schema, serialization_type=serialization_type, writer_schema=writer_schema
+        )
 
         if create_instance:
             return from_dict(data_class=cls, data=payload, config=Config(**cls.config()))
@@ -99,7 +110,7 @@ class AvroModel:
 
     def to_json(self) -> typing.Dict:
         # Serialize using the current AVRO schema to get proper field representations
-        # and after that conver into python
+        # and after that convert into python
         data = self.asdict()
         return serialization.to_json(data)
 

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -30,11 +30,20 @@ def serialize(payload: typing.Dict, schema: typing.Dict, serialization_type: str
     return value  # type: ignore
 
 
-def deserialize(data: bytes, schema: typing.Dict, serialization_type: str = "avro") -> typing.Dict:
+def deserialize(
+    data: bytes,
+    schema: typing.Dict,
+    serialization_type: str = "avro",
+    writer_schema: typing.Optional[typing.Dict] = None,
+) -> typing.Dict:
     if serialization_type == "avro":
         input_stream: typing.Union[io.BytesIO, io.StringIO] = io.BytesIO(data)
 
-        payload = fastavro.schemaless_reader(input_stream, schema)
+        payload = fastavro.schemaless_reader(
+            input_stream,
+            writer_schema=writer_schema or schema,
+            reader_schema=schema,
+        )
 
     elif serialization_type == "avro-json":
         input_stream = io.StringIO(data.decode())

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -52,6 +52,7 @@ def is_custom_type(value: typing.Any) -> bool:
 
 @dataclass
 class SchemaMetadata:
+    schema_name: typing.Optional[str] = None
     schema_doc: bool = True
     namespace: typing.Optional[typing.List[str]] = None
     aliases: typing.Optional[typing.List[str]] = None
@@ -59,6 +60,7 @@ class SchemaMetadata:
     @classmethod
     def create(cls, klass: typing.Any) -> typing.Any:
         return cls(
+            schema_name=getattr(klass, "schema_name", None),
             schema_doc=getattr(klass, "schema_doc", True),
             namespace=getattr(klass, "namespace", None),
             aliases=getattr(klass, "aliases", None),

--- a/docs/complex_types.md
+++ b/docs/complex_types.md
@@ -2,15 +2,15 @@
 
 The following list represent the avro complext types mapped to python types:
 
-| Avro Type | Python Type |
-|-----------|-------------|
-| enums     |   types.Enum     |
-| arrays    |   typing.List, typing.Tuple, typing.Sequence, typing.MutableSequence      |
-| maps      |   typing.Dict, typing.Mapping, typing.MutableMapping      |
-| fixed     | types.Fixed |
-| unions    |typing.Union |
-| unions with `null`  |typing.Optional |
-| records   |Python Class |
+| Avro Type          | Python Type                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| enums              | types.Enum                                                         |
+| arrays             | typing.List, typing.Tuple, typing.Sequence, typing.MutableSequence |
+| maps               | typing.Dict, typing.Mapping, typing.MutableMapping                 |
+| fixed              | types.Fixed                                                        |
+| unions             | typing.Union                                                       |
+| unions with `null` | typing.Optional                                                    |
+| records            | Python Class                                                       |
 
 ### Enums
 
@@ -401,10 +401,11 @@ User.avro_schema()
 
 #### Class Meta
 
-The `class Meta` is used to specify schema attributes that are not reprsented by the class fields like `namespace`, `aliases` and whether include the `schema documentation`.
+The `class Meta` is used to specify schema attributes that are not represented by the class fields like `namespace`, `aliases` and whether to include the `schema documentation`. One can also provide a custom schema name (the default is the class' name) via `schema_name` attribute.
 
 ```python
 class Meta:
+    schema_name = "Name other than the class name"
     schema_doc = False
     namespace = "test.com.ar/user/v1"
     aliases = ["User", "My favorite User"]

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -79,7 +79,7 @@ avro_json_binary = b'{"name": "john", "age": 20, "addresses": [{"street": "test"
 
 # return a new class instance!!
 User.deserialize(avro_binary)
-# >>>> User(name='john', age=20, addresses=[Address(street='test', street_number=10)])
+# >>> User(name='john', age=20, addresses=[Address(street='test', street_number=10)])
 
 # return a python dict
 User.deserialize(avro_binary, create_instance=False)
@@ -87,11 +87,44 @@ User.deserialize(avro_binary, create_instance=False)
 
 # return a new class instance!!
 User.deserialize(avro_json_binary, serialization_type="avro-json")
-# >>>> User(name='john', age=20, addresses=[Address(street='test', street_number=10)])
+# >>> User(name='john', age=20, addresses=[Address(street='test', street_number=10)])
 
 # return a python dict
 User.deserialize(avro_json_binary, serialization_type="avro-json", create_instance=False)
 # >>> {"name": "john", "age": 20, "addresses": [{"street": "test", "street_number": 10}]}
+```
+
+#### Deserialization of records encoded via a different schema
+To deserialize data encoded via a different schema, one can pass an optional `writer_schema: AvroModel | dict[str, Any]` attribute. It will be used by the **fastavro**s `schemaless_reader`.
+
+```python
+@dataclass
+class User(AvroModel):
+    name: str
+    age: int
+
+
+@dataclass
+class UserCompatible(AvroModel):
+    name: str
+    age: int
+    nickname: Optional[str] = None
+
+    class Meta:
+        schema_name = "User"
+
+
+user_data = {
+    "name": "G.R. Emlin",
+    "age": 52,
+}
+
+# serialize data with the User schema
+>>> serialized_user = User(**user_data).serialize()
+
+# deserialize user using a new, but compatible schema
+>>> deserialized_user = UserCompatible.deserialize(serialized_user, writer_schema=User)
+
 ```
 
 ### Custom Serialization

--- a/tests/serialization/test_serialization.py
+++ b/tests/serialization/test_serialization.py
@@ -26,6 +26,18 @@ class User(AvroModel):
     addresses: typing.List[Address]
 
 
+@dataclass
+class UserCompatible(AvroModel):
+    "User with multiple Address"
+    name: str
+    age: int
+    addresses: typing.List[Address]
+    nickname: typing.Optional[str] = None
+
+    class Meta:
+        schema_name = "User"
+
+
 address_data = {
     "street": "test",
     "street_number": 10,
@@ -169,3 +181,14 @@ def test_invalid_serialization_deserialization_types():
 
     with pytest.raises(ValueError):
         user.deserialize(b"", serialization_type="json")
+
+
+def test_deserialization_with_writer_schema__dict():
+    user = User(**data_user)
+    writer_schema = User.avro_schema_to_python()
+    UserCompatible.deserialize(user.serialize(), writer_schema=writer_schema)
+
+
+def test_deserialization_with_writer_schema__avro_model():
+    user = User(**data_user)
+    UserCompatible.deserialize(user.serialize(), writer_schema=User)


### PR DESCRIPTION
Currently, it's not possible to deserialize records encoded with a different, but compatible schema. This **PR** introduces an optional `writer_schema` argument to `AvroModel.deserialize`. This corresponds directly to the underlying **fastavro** `schema_less_reader` that executes the deserialization.

Additionally, this **PR** introduces a possibility to customize the `name` attribute in the generated Avro schema.
