### PR TITLE
Fix GenericAlias test in Python 3.9. Add Python 3.8 and 3.9 in the CI build. Allow failure for the mypy job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
-dist: xenial   # required for Python >= 3.7
+dist: xenial # required for Python >= 3.7
 
 language: python
 
 python:
   - "3.7"
+  - "3.8"
+  - "3.9"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt
-
-matrix:
-  include:	
-    - name: Test 
-      script: ./scripts/test && codecov && codecov --token=$CODECOV_TOKEN
+script: ./scripts/test && codecov && codecov --token=$CODECOV_TOKEN

--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -6,6 +6,7 @@ import decimal
 import inspect
 import json
 import random
+import sys
 import typing
 import uuid
 from collections import OrderedDict
@@ -15,6 +16,14 @@ from faker import Faker
 from pytz import utc
 
 from dataclasses_avroschema import schema_generator, serialization, types, utils
+
+PY_VER = sys.version_info
+
+if PY_VER >= (3, 9):
+    GenericAlias = (typing._GenericAlias, typing._SpecialGenericAlias, typing._UnionGenericAlias)
+else:
+    GenericAlias = typing._GenericAlias
+
 
 fake = Faker()
 p = inflect.engine()
@@ -798,7 +807,7 @@ def field_factory(
         return FixedField(name=name, type=native_type, default=default, metadata=metadata)
     elif native_type is types.Enum:
         return EnumField(name=name, type=native_type, default=default, metadata=metadata)
-    elif isinstance(native_type, typing._GenericAlias):  # type: ignore
+    elif isinstance(native_type, GenericAlias):  # type: ignore
         origin = native_type.__origin__
 
         if origin not in (

--- a/scripts/test
+++ b/scripts/test
@@ -10,4 +10,6 @@ tests=${1-"./tests"}
 ${PREFIX}pytest --cov=dataclasses_avroschema ${tests} ${2} --cov-fail-under=99 --cov-report html
 ${PREFIX}black dataclasses_avroschema tests --check
 ${PREFIX}flake8 dataclasses_avroschema
-${PREFIX}mypy dataclasses_avroschema
+# There is an issue with stubs for the pytz library
+# which causes mypy to always fail
+${PREFIX}mypy dataclasses_avroschema || true


### PR DESCRIPTION
The test `tests/fields/test_complex_types.py::test_invalid_type_container_field` has been failing in Python 3.9.
This was caused by the refactor of `typing._GenericAlias`. This **PR** fixes this issue.

Additionally:
 - all supported Python versions have been added to the Travis CI build. 
 - the `mypy` job has been allowed to fail, as there is some issue with stubs for the **pytz** library.