### PR TITLE
Improve type annotations. 

### DIFF
--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -183,7 +183,7 @@ class BaseField:
         return None
 
 
-class InmutableField(BaseField):
+class ImmutableField(BaseField):
     def get_avro_type(self) -> PythonImnutableTypes:
         if self.default is None:
             return [NULL, self.avro_type]
@@ -191,7 +191,7 @@ class InmutableField(BaseField):
 
 
 @dataclasses.dataclass
-class StringField(InmutableField):
+class StringField(ImmutableField):
     avro_type: typing.ClassVar = STRING
 
     def fake(self) -> str:
@@ -199,7 +199,7 @@ class StringField(InmutableField):
 
 
 @dataclasses.dataclass
-class LongField(InmutableField):
+class LongField(ImmutableField):
     avro_type: typing.ClassVar = LONG
 
     def fake(self) -> int:
@@ -207,7 +207,7 @@ class LongField(InmutableField):
 
 
 @dataclasses.dataclass
-class BooleanField(InmutableField):
+class BooleanField(ImmutableField):
     avro_type: typing.ClassVar = BOOLEAN
 
     def fake(self) -> bool:
@@ -215,7 +215,7 @@ class BooleanField(InmutableField):
 
 
 @dataclasses.dataclass
-class DoubleField(InmutableField):
+class DoubleField(ImmutableField):
     avro_type: typing.ClassVar = DOUBLE
 
     def fake(self) -> float:
@@ -223,7 +223,7 @@ class DoubleField(InmutableField):
 
 
 @dataclasses.dataclass
-class BytesField(InmutableField):
+class BytesField(ImmutableField):
     avro_type: typing.ClassVar = BYTES
 
     def get_default_value(self) -> typing.Any:
@@ -242,7 +242,7 @@ class BytesField(InmutableField):
 
 
 @dataclasses.dataclass
-class NoneField(InmutableField):
+class NoneField(ImmutableField):
     avro_type: typing.ClassVar = NULL
 
 
@@ -502,7 +502,7 @@ class SelfReferenceField(BaseField):
         return dataclasses.MISSING
 
 
-class LogicalTypeField(InmutableField):
+class LogicalTypeField(ImmutableField):
     def get_default_value(self) -> typing.Union[None, str, int, float]:
         if self.default in (dataclasses.MISSING, None):
             return self.default
@@ -787,7 +787,7 @@ FieldType = typing.Union[
     DatetimeField,
     UUIDField,
     RecordField,
-    InmutableField,
+    ImmutableField,
 ]
 
 

--- a/dataclasses_avroschema/schema_generator.py
+++ b/dataclasses_avroschema/schema_generator.py
@@ -4,19 +4,24 @@ import typing
 
 from dacite import Config, from_dict
 
-from dataclasses_avroschema import schema_definition, serialization, utils
+from dataclasses_avroschema.schema_definition import AvroSchemaDefinition
+from dataclasses_avroschema.serialization import deserialize, serialize, to_json
+from dataclasses_avroschema.utils import SchemaMetadata, is_custom_type
 
 from .fields import FieldType
 
 AVRO = "avro"
 AVRO_JSON = "avro-json"
 
+JsonDict = typing.Dict[str, typing.Any]
+CT = typing.TypeVar("CT", bound="AvroModel")
+
 
 class AvroModel:
 
-    schema_def: typing.Optional[schema_definition.AvroSchemaDefinition] = None
+    schema_def: typing.Optional[AvroSchemaDefinition] = None
     klass: typing.Any = None
-    metadata: typing.Optional[typing.Dict] = None
+    metadata: typing.Optional[SchemaMetadata] = None
 
     @classmethod
     def generate_dataclass(cls: typing.Any) -> typing.Any:
@@ -25,15 +30,15 @@ class AvroModel:
         return dataclasses.dataclass(cls)
 
     @classmethod
-    def generate_metadata(cls: typing.Any) -> utils.SchemaMetadata:
+    def generate_metadata(cls: typing.Any) -> SchemaMetadata:
         meta = getattr(cls.klass, "Meta", None)
 
         if meta is None:
-            return utils.SchemaMetadata()
-        return utils.SchemaMetadata.create(meta)
+            return SchemaMetadata()
+        return SchemaMetadata.create(meta)
 
     @classmethod
-    def generate_schema(cls: typing.Any, schema_type: str = "avro") -> typing.Dict:
+    def generate_schema(cls: typing.Type[CT], schema_type: str = "avro") -> AvroSchemaDefinition:
         if cls.schema_def is None:
             # Generate metaclass and metadata
             cls.klass = cls.generate_dataclass()
@@ -50,8 +55,8 @@ class AvroModel:
         return cls.schema_def
 
     @classmethod
-    def _generate_avro_schema(cls: typing.Any) -> schema_definition.AvroSchemaDefinition:
-        return schema_definition.AvroSchemaDefinition("record", cls.klass, metadata=cls.metadata)
+    def _generate_avro_schema(cls: typing.Any) -> AvroSchemaDefinition:
+        return AvroSchemaDefinition("record", cls.klass, metadata=cls.metadata)
 
     @classmethod
     def avro_schema(cls: typing.Any) -> str:
@@ -69,11 +74,11 @@ class AvroModel:
 
     @staticmethod
     def standardize_custom_type(value: typing.Any) -> typing.Any:
-        if utils.is_custom_type(value):
+        if is_custom_type(value):
             return value["default"]
         return value
 
-    def asdict(self) -> typing.Dict:
+    def asdict(self) -> JsonDict:
         data = dataclasses.asdict(self)
 
         # te standardize called can be replaced if we have a custom implementation of asdict
@@ -83,16 +88,16 @@ class AvroModel:
     def serialize(self, serialization_type: str = AVRO) -> bytes:
         schema = self.avro_schema_to_python()
 
-        return serialization.serialize(self.asdict(), schema, serialization_type=serialization_type)
+        return serialize(self.asdict(), schema, serialization_type=serialization_type)
 
     @classmethod
     def deserialize(
-        cls,
+        cls: typing.Type[CT],
         data: bytes,
         serialization_type: str = AVRO,
         create_instance: bool = True,
-        writer_schema: typing.Optional[typing.Union[typing.Dict[str, typing.Any], "AvroModel"]] = None,
-    ) -> typing.Union[typing.Dict, "AvroModel"]:
+        writer_schema: typing.Optional[typing.Union[JsonDict, CT]] = None,
+    ) -> typing.Union[JsonDict, CT]:
 
         try:
             writer_schema = writer_schema.avro_schema_to_python()
@@ -100,22 +105,20 @@ class AvroModel:
             pass
 
         schema = cls.avro_schema_to_python()
-        payload = serialization.deserialize(
-            data, schema, serialization_type=serialization_type, writer_schema=writer_schema
-        )
+        payload = deserialize(data, schema, serialization_type=serialization_type, writer_schema=writer_schema)
 
         if create_instance:
             return from_dict(data_class=cls, data=payload, config=Config(**cls.config()))
         return payload
 
-    def to_json(self) -> typing.Dict:
+    def to_json(self) -> JsonDict:
         # Serialize using the current AVRO schema to get proper field representations
         # and after that convert into python
         data = self.asdict()
-        return serialization.to_json(data)
+        return to_json(data)
 
     @classmethod
-    def config(cls) -> typing.Dict:
+    def config(cls) -> JsonDict:
         """
         Get the default config for dacite and always include the self reference
         """
@@ -127,7 +130,7 @@ class AvroModel:
         }
 
     @classmethod
-    def fake(cls) -> typing.Any:
+    def fake(cls: typing.Type[CT]) -> CT:
         payload = {field.name: field.fake() for field in cls.get_fields()}
 
         return from_dict(data_class=cls, data=payload, config=Config(**cls.config()))

--- a/dataclasses_avroschema/types.py
+++ b/dataclasses_avroschema/types.py
@@ -35,7 +35,7 @@ class Enum(typing.Generic[T]):
     """
     Represents an Avro Enum type
 
-    simbols (typing.List): Specifying the possible values for the enum
+    symbols (typing.List): Specifying the possible values for the enum
     """
 
     symbols: typing.List[typing.Any]


### PR DESCRIPTION
This PR introduces some improvements of type annotations in the `AvroModel` class.

Most importantly, `deserialize` and `fake` methods, which now have correct and generic return types.