### PR TITLE
fix: new style type annotations don't work for containers and maps

### DIFF
--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -22,7 +22,7 @@ from .exceptions import NameSpaceRequiredException
 PY_VER = sys.version_info
 
 if PY_VER >= (3, 9):
-    GenericAlias = (typing._GenericAlias, typing._SpecialGenericAlias, typing._UnionGenericAlias)
+    GenericAlias = (typing.GenericAlias, typing._GenericAlias, typing._SpecialGenericAlias, typing._UnionGenericAlias)
 else:
     GenericAlias = typing._GenericAlias
 

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -129,8 +129,8 @@ OPTIONAL_UNION_COMPLEX_TYPES = (
 )
 
 
-SEQUENCE_TYPES = (typing.List, typing.Tuple, typing.Sequence, typing.MutableSequence)
-MAPPING_TYPES = (typing.Dict, typing.Mapping, typing.MutableMapping)
+SEQUENCE_TYPES = (typing.List, typing.Tuple, typing.Sequence, typing.MutableSequence, list, tuple)
+MAPPING_TYPES = (typing.Dict, typing.Mapping, typing.MutableMapping, dict)
 
 SEQUENCES_AND_TYPES = [
     (sequence, python_type, items_type) for sequence in SEQUENCE_TYPES for python_type, items_type in PRIMITIVE_TYPES

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -1,8 +1,13 @@
 import datetime
 import typing
 import uuid
+import sys
+
+import pytest
 
 from dataclasses_avroschema import AvroModel, fields
+
+PY_VER = sys.version_info
 
 now = datetime.datetime.now()
 
@@ -129,25 +134,36 @@ OPTIONAL_UNION_COMPLEX_TYPES = (
 )
 
 
+def xfail_annotation(typ):
+    return pytest.mark.xfail(
+        (typ in (list, tuple, dict) and PY_VER < (3, 9)),
+        reason="Standard collection annotations not supported - see PEP585.",
+    )
+
+
 SEQUENCE_TYPES = (typing.List, typing.Tuple, typing.Sequence, typing.MutableSequence, list, tuple)
 MAPPING_TYPES = (typing.Dict, typing.Mapping, typing.MutableMapping, dict)
 
 SEQUENCES_AND_TYPES = [
-    (sequence, python_type, items_type) for sequence in SEQUENCE_TYPES for python_type, items_type in PRIMITIVE_TYPES
+    pytest.param(sequence, python_type, items_type, marks=xfail_annotation(sequence))
+    for sequence in SEQUENCE_TYPES
+    for python_type, items_type in PRIMITIVE_TYPES
 ]
 
 SEQUENCES_LOGICAL_TYPES = [
-    (sequence, python_type, items_type, value)
+    pytest.param(sequence, python_type, items_type, value, marks=xfail_annotation(sequence))
     for sequence in SEQUENCE_TYPES
     for python_type, items_type, value in LOGICAL_TYPES
 ]
 
 MAPPING_AND_TYPES = [
-    (mapping, python_type, items_type) for mapping in MAPPING_TYPES for python_type, items_type in PRIMITIVE_TYPES
+    pytest.param(mapping, python_type, items_type, marks=xfail_annotation(mapping))
+    for mapping in MAPPING_TYPES
+    for python_type, items_type in PRIMITIVE_TYPES
 ]
 
 MAPPING_LOGICAL_TYPES = [
-    (mapping, python_type, items_type, value)
+    pytest.param(mapping, python_type, items_type, value, marks=xfail_annotation(mapping))
     for mapping in MAPPING_TYPES
     for python_type, items_type, value in LOGICAL_TYPES
 ]


### PR DESCRIPTION
```python
class MyModel(AvroModel):
    my_dict: dict[str, Any]
    my_list: list[int]
    my_tuple: tuple[str]
```

Would previously fail