### PR TITLE
Standardize the elements of lists and tuples

### DIFF
--- a/dataclasses_avroschema/schema_generator.py
+++ b/dataclasses_avroschema/schema_generator.py
@@ -123,6 +123,8 @@ class AvroModel:
     def standardize_custom_type(value: typing.Any) -> typing.Any:
         if is_custom_type(value):
             return value["default"]
+        elif isinstance(value,list) or isinstance(value,tuple):
+            return [AvroModel.standardize_custom_type(v) for v in value]
         elif isinstance(value, dict):
             return {k: AvroModel.standardize_custom_type(v) for k, v in value.items()}
         elif issubclass(type(value), enum.Enum):


### PR DESCRIPTION
The `standardize_custom_type` function currently translates the elements of dicts and enums but not lists (or tuples). This means that if you try to serialise a class containing a list of custom classes then they don't get mapped. Also, if you try to serialise a class containing a tuple field it fails to be mapped to a list.

This change adds a mapping covering these cases.