### PR TITLE
Generate a Python module from multiple schemas

### DIFF
--- a/dataclasses_avroschema/model_generator/generator.py
+++ b/dataclasses_avroschema/model_generator/generator.py
@@ -139,11 +139,18 @@ class ModelGenerator:
 
     def render(self, *, schema: JsonDict) -> str:
         """
-        Render the module with the classes generated from the schema/s
+        Render the module with the classes generated from the schema
         """
-        self.validate_schema(schema=schema)
+        return self.render_module(schemas=[schema])
 
-        classes = self.render_class(schema=schema)
+    def render_module(self, *, schemas: typing.List[JsonDict]) -> str:
+        """
+        Render the module with the classes generated from the schemas
+        """
+        for schema in schemas:
+            self.validate_schema(schema=schema)
+
+        classes = "\n".join(self.render_class(schema=schema) for schema in schemas)
         imports = self.render_imports()
         extras = self.render_extras()
 

--- a/docs/model_generator.md
+++ b/docs/model_generator.md
@@ -55,6 +55,58 @@ class AvroDeployment(AvroModel):
         namespace = "com.kubertenes"
 ```
 
+## Render a Python module
+
+It's also possible to generate a Python module containing classes from multiple schemas using `render_module`.
+
+```py
+from dataclasses_avroschema import ModelGenerator
+
+model_generator = ModelGenerator()
+
+user_schema = {
+    "type": "record",
+    "name": "User",
+    "fields": [
+        {"name": "name", "type": "string", "default": "marcos"},
+        {"name": "age", "type": "int"},
+    ],
+}
+address_schema = {
+    "type": "record",
+    "name": "Address",
+    "fields": [
+        {"name": "street", "type": "string"},
+        {"name": "street_number", "type": "long"},
+    ],
+}
+
+result = model_generator.render_module(schemas=[user_schema, address_schema])
+
+with open("models.py", mode="+w") as f:
+    f.write(result)
+```
+```py
+# models.py
+from dataclasses_avroschema import AvroModel
+from dataclasses_avroschema import types
+import dataclasses
+
+
+@dataclasses.dataclass
+class User(AvroModel):
+    age: types.Int32
+    name: str = "marcos"
+
+
+@dataclasses.dataclass
+class Address(AvroModel):
+    street: str
+    street_number: int
+```
+
+Generating a single module from multiple schemas is useful for example to group schemas that belong to the same namespace.
+
 ## Render Pydantic models
 
 It is also possible to render `BaseModel` (pydantic) and `AvroBaseModel` (avro + pydantic) models as well simply specifying the `base class`.

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -31,6 +31,19 @@ def schema() -> Dict:
 
 
 @pytest.fixture
+def schema_2() -> Dict:
+    return {
+        "type": "record",
+        "name": "Address",
+        "fields": [
+            {"name": "street", "type": "string"},
+            {"name": "street_number", "type": "long"},
+        ],
+        "doc": "An Address",
+    }
+
+
+@pytest.fixture
 def schema_with_nulls() -> Dict:
     return {
         "type": "record",

--- a/tests/model_generator/test_model_generator.py
+++ b/tests/model_generator/test_model_generator.py
@@ -322,3 +322,40 @@ class LogicalTypes(AvroModel):
     with open("models.py", mode="w+") as f:
         f.write(result)
     assert result.strip() == expected_result.strip()
+
+
+def test_model_generator_render_module_from_multiple_schemas(schema: types.JsonDict, schema_2: types.JsonDict) -> None:
+    expected_result = """
+from dataclasses_avroschema import AvroModel
+from dataclasses_avroschema import types
+import dataclasses
+
+
+@dataclasses.dataclass
+class User(AvroModel):
+    age: types.Int32
+    weight: types.Int32
+    money_available: float
+    name: str = "marcos"
+    pet_age: types.Int32 = 1
+    height: types.Float32 = 10.1
+    is_student: bool = True
+    encoded: bytes = b"Hi"
+
+    class Meta:
+        namespace = "test"
+        schema_doc = "An User"
+        aliases = ['schema', 'test-schema']
+
+
+@dataclasses.dataclass
+class Address(AvroModel):
+    street: str
+    street_number: int
+
+    class Meta:
+        schema_doc = "An Address"
+"""
+    model_generator = ModelGenerator()
+    result = model_generator.render_module(schemas=[schema, schema_2])
+    assert result.strip() == expected_result.strip()


### PR DESCRIPTION
The new `render_module` method generates a Python module containing classes from one or more schemas (as opposed to `render` that accepts only one schema).

Generating a single module from multiple schemas is useful for example to group schemas that belong to the same namespace.