### PR TITLE
fix: use pydantic UUID4 when generating pydantic models.

### DIFF
--- a/dataclasses_avroschema/model_generator/avro_to_python_utils.py
+++ b/dataclasses_avroschema/model_generator/avro_to_python_utils.py
@@ -4,8 +4,9 @@ import typing
 from dataclasses_avroschema import field_utils
 
 from . import templates
+from .base_class import BaseClassEnum
 
-AVRO_TYPE_TO_PYTHON: typing.Dict[str, str] = {
+_AVRO_TYPE_TO_PYTHON: typing.Dict[str, str] = {
     field_utils.BOOLEAN: "bool",
     field_utils.LONG: "int",
     field_utils.DOUBLE: "float",
@@ -22,7 +23,19 @@ AVRO_TYPE_TO_PYTHON: typing.Dict[str, str] = {
     field_utils.UUID: "uuid.uuid4",
 }
 
-LOGICAL_TYPES_IMPORTS: typing.Dict[str, str] = {
+AVRO_TYPE_TO_PYTHON: typing.Dict[str, typing.Dict[str, str]] = {
+    BaseClassEnum.AVRO_MODEL.value: _AVRO_TYPE_TO_PYTHON,
+    BaseClassEnum.PYDANTIC_MODEL.value: {
+        **_AVRO_TYPE_TO_PYTHON,
+        field_utils.UUID: "pydantic.UUID4",
+    },
+    BaseClassEnum.AVRO_DANTIC_MODEL.value: {
+        **_AVRO_TYPE_TO_PYTHON,
+        field_utils.UUID: "pydantic.UUID4",
+    },
+}
+
+_LOGICAL_TYPES_IMPORTS: typing.Dict[str, str] = {
     field_utils.DECIMAL: "import decimal",
     field_utils.DATE: "import datetime",
     field_utils.TIME_MILLIS: "import datetime",
@@ -30,6 +43,17 @@ LOGICAL_TYPES_IMPORTS: typing.Dict[str, str] = {
     field_utils.TIMESTAMP_MILLIS: "import datetime",
     field_utils.TIMESTAMP_MICROS: "from dataclasses_avroschema import types",
     field_utils.UUID: "import uuid",
+}
+LOGICAL_TYPES_IMPORTS: typing.Dict[str, typing.Dict[str, str]] = {
+    BaseClassEnum.AVRO_MODEL.value: _LOGICAL_TYPES_IMPORTS,
+    BaseClassEnum.PYDANTIC_MODEL.value: {
+        **_LOGICAL_TYPES_IMPORTS,
+        field_utils.UUID: "import pydantic",
+    },
+    BaseClassEnum.AVRO_DANTIC_MODEL.value: {
+        **_LOGICAL_TYPES_IMPORTS,
+        field_utils.UUID: "import pydantic",
+    },
 }
 
 # Avro types to python types

--- a/dataclasses_avroschema/model_generator/base_class.py
+++ b/dataclasses_avroschema/model_generator/base_class.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class BaseClassEnum(str, enum.Enum):
+    AVRO_MODEL = "AvroModel"
+    PYDANTIC_MODEL = "BaseModel"
+    AVRO_DANTIC_MODEL = "AvroBaseModel"

--- a/docs/model_generator.md
+++ b/docs/model_generator.md
@@ -201,6 +201,9 @@ and then render the result:
 !!! note
     `decimal.Decimal` are created using `pydantic condecimal`
 
+!!! note
+    `uuid` types are created using `pydantic.UUID4`
+
 ## Malformed schemas
 
 Some times there are valid avro schemas but we could say that it is "malformed", for example the following schema has a field name called `Address` which is


### PR DESCRIPTION
This PR updates pydantic model generation to use `pydantic.UUID4` instead of `uuid.uuid4`. The latter crashes pydantic. 🙃 Thank you for the fantastic library!