### PR TITLE
fix: correctly generate enum default values

### DIFF
--- a/dataclasses_avroschema/fields.py
+++ b/dataclasses_avroschema/fields.py
@@ -671,16 +671,10 @@ class DatetimeField(LogicalTypeField):
         return field_utils.LOGICAL_DATETIME_MILIS
 
     @staticmethod
-    def to_avro(date_time: datetime.datetime) -> float:
+    def to_avro(date_time: datetime.datetime) -> int:
         """
         Returns the number of milliseconds from the unix epoch,
         1 January 1970 00:00:00.000 UTC for a given datetime
-
-        Arguments:
-            date_time (datetime.datetime)
-
-        Returns:
-            float
         """
         if date_time.tzinfo:
             ts = (date_time - utils.epoch).total_seconds()
@@ -709,16 +703,10 @@ class DatetimeMicroField(LogicalTypeField):
         return field_utils.LOGICAL_DATETIME_MICROS
 
     @staticmethod
-    def to_avro(date_time: datetime.datetime) -> float:
+    def to_avro(date_time: datetime.datetime) -> int:
         """
         Returns the number of milliseconds from the unix epoch,
         1 January 1970 00:00:00.000000 UTC for a given datetime
-
-        Arguments:
-            date_time (datetime.datetime)
-
-        Returns:
-            float
         """
         if date_time.tzinfo:
             ts = (date_time - utils.epoch).total_seconds()

--- a/dataclasses_avroschema/model_generator/avro_to_python_utils.py
+++ b/dataclasses_avroschema/model_generator/avro_to_python_utils.py
@@ -7,6 +7,7 @@ from . import templates
 from .base_class import BaseClassEnum
 
 _AVRO_TYPE_TO_PYTHON: typing.Dict[str, str] = {
+    field_utils.NULL: "None",
     field_utils.BOOLEAN: "bool",
     field_utils.LONG: "int",
     field_utils.DOUBLE: "float",
@@ -61,8 +62,10 @@ LOGICAL_TYPES_TO_PYTHON = {
     field_utils.DATE: lambda value: datetime.date.fromtimestamp(60 * 60 * 24 * value),
     field_utils.TIME_MILLIS: lambda value: (datetime.datetime.min + datetime.timedelta(milliseconds=value)).time(),
     field_utils.TIME_MICROS: lambda value: (datetime.datetime.min + datetime.timedelta(microseconds=value)).time(),
-    field_utils.TIMESTAMP_MILLIS: lambda value: datetime.datetime.fromtimestamp(value / 1000),
-    field_utils.TIMESTAMP_MICROS: lambda value: datetime.datetime.fromtimestamp(value / 1000000),
+    field_utils.TIMESTAMP_MILLIS: lambda value: datetime.datetime.fromtimestamp(value / 1000, tz=datetime.timezone.utc),
+    field_utils.TIMESTAMP_MICROS: lambda value: datetime.datetime.fromtimestamp(
+        value / 1000000, tz=datetime.timezone.utc
+    ),
 }
 
 # Logical types objects to template

--- a/dataclasses_avroschema/model_generator/templates.py
+++ b/dataclasses_avroschema/model_generator/templates.py
@@ -4,31 +4,33 @@ FIELD_TEMPLATE = "$name: $type"
 METACLASS_FIELD_TEMPLATE = '$name = "$value"'
 METACLASS_ALIAS_FIELD = "$name = $value"
 FIELD_DEFAULT_TEMPLATE = " = $default"
-OPTIONAL_TEMPLATE = "typing.Optional[$type] = None"
+OPTIONAL_TEMPLATE = "typing.Optional[$type]"
 UNION_TEMPLATE = "typing.Union[$type]"
 LIST_TEMPLATE = "typing.List[$type]"
 DICT_TEMPLATE = "typing.Dict[str, $type]"
 FIXED_TEMPLATE = "types.Fixed = types.Fixed($properties)"
 DATACLASS_FIELD = "dataclasses.field($properties)"
-TYPE_TEMPLATE = 'typing.Type["$type"]'
+TYPE_TEMPLATE = '"$type"'
 DATE_TEMPLATE = "datetime.date($year, $month, $day)"
 TIME_TEMPLATE = "datetime.time($hour, $minute, $second)"
 TIME_MICROS_TEMPLATE = "datetime.time($hour, $minute, $second, $microsecond)"
-DATETIME_TEMPLATE = "datetime.datetime($year, $month, $day, $hour, $minute, $second)"
-DATETIME_MICROS_TEMPLATE = "datetime.datetime($year, $month, $day, $hour, $minute, $second, $microsecond)"
+DATETIME_TEMPLATE = "datetime.datetime($year, $month, $day, $hour, $minute, $second, tzinfo=datetime.timezone.utc)"
+DATETIME_MICROS_TEMPLATE = (
+    "datetime.datetime($year, $month, $day, $hour, $minute, $second, $microsecond, tzinfo=datetime.timezone.utc)"
+)
 DECIMAL_TEMPLATE = "decimal.Decimal('$value')"
 DECIMAL_TYPE_TEMPLATE = "types.Decimal($properties)"
 
 ENUM_SYMBOL_TEMPLATE = "$key = $value"
 ENUM_TEMPLATE = """
 
-class $name(enum.Enum):
+class $name(enum.Enum):$docstring
     $symbols
 """
 
 CLASS_TEMPLATE = """
 $decorator
-class $name($base_class):
+class $name($base_class):$docstring
     $fields
 """
 

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -1,8 +1,7 @@
 import dataclasses
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 
-from pytz import utc
 from typing_extensions import Annotated, get_origin
 
 from .types import JsonDict
@@ -122,5 +121,5 @@ class UserDefinedType(typing.NamedTuple):
     type: typing.Any
 
 
-epoch: datetime = datetime(1970, 1, 1, tzinfo=utc)
+epoch: datetime = datetime(1970, 1, 1, tzinfo=timezone.utc)
 epoch_naive: datetime = datetime(1970, 1, 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,8 @@ def user_dataclass():
 def user_dataclass_with_doc():
     @dataclasses.dataclass(repr=False)
     class User(AvroModel):
+        """I am documented."""
+
         name: str
         age: int
         has_pets: bool

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -10,7 +10,7 @@ from dataclasses_avroschema import field_utils
 
 PY_VER = sys.version_info
 
-now = datetime.datetime.now()
+now = datetime.datetime.now(tz=datetime.timezone.utc)
 
 PRIMITIVE_TYPES = (
     (str, field_utils.STRING),

--- a/tests/fields/test_complex_types.py
+++ b/tests/fields/test_complex_types.py
@@ -268,7 +268,7 @@ def test_union_type_with_default(union, avro_types, default) -> None:
     field = fields.AvroField(name, union, default=default)
 
     if isinstance(default, datetime.datetime):
-        default = int((default - datetime.datetime(1970, 1, 1)).total_seconds() * 1000)
+        default = int(default.timestamp() * 1000)
     elif isinstance(default, bytes):
         default = default.decode()
 

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -103,7 +103,7 @@ def test_logical_type_datetime_micros_with_default() -> None:
     python_type = types.DateTimeMicro
     field = fields.AvroField(name, python_type, default=consts.now)
 
-    ts = (consts.now - datetime.datetime(1970, 1, 1)).total_seconds()
+    ts = consts.now.timestamp()
 
     expected = {
         "name": name,
@@ -119,7 +119,7 @@ def test_logical_type_datetime_with_default() -> None:
     python_type = datetime.datetime
     field = fields.AvroField(name, python_type, default=consts.now)
 
-    ts = (consts.now - datetime.datetime(1970, 1, 1)).total_seconds()
+    ts = consts.now.timestamp()
 
     expected = {
         "name": name,

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -26,7 +26,7 @@ def schema() -> Dict:
         ],
         "doc": "An User",
         "namespace": "test",
-        "alias": ["schema", "test-schema"],
+        "aliases": ["schema", "test-schema"],
     }
 
 
@@ -81,7 +81,7 @@ def schema_with_unions() -> Dict:
                 "type": "boolean",
                 "default": True,
             },
-            {"name": "money_available", "type": "double"},
+            {"name": "money_available", "type": ["double"]},
             {"name": "encoded", "type": "bytes", "default": "Hi"},
         ],
     }

--- a/tests/model_generator/test_model_generator.py
+++ b/tests/model_generator/test_model_generator.py
@@ -11,6 +11,9 @@ import dataclasses
 
 @dataclasses.dataclass
 class User(AvroModel):
+    \"""
+    An User
+    \"""
     age: types.Int32
     weight: types.Int32
     money_available: float
@@ -22,7 +25,6 @@ class User(AvroModel):
 
     class Meta:
         namespace = "test"
-        schema_doc = "An User"
         aliases = ['schema', 'test-schema']
 """
     model_generator = ModelGenerator()
@@ -44,7 +46,7 @@ class User(AvroModel):
     money_available: float
     name: typing.Optional[str] = None
     age: typing.Optional[types.Int32] = None
-    pet_age: types.Int32 = 1
+    pet_age: typing.Optional[types.Int32] = 1
     height: types.Float32 = 10.1
     is_student: bool = True
     encoded: bytes = b"Hi"
@@ -69,7 +71,7 @@ class User(AvroModel):
     age: typing.Union[types.Int32, str] = 10
     pet_age: typing.Union[str, bool] = "bond"
     height: types.Float32 = 10.1
-    weight: typing.Optional[typing.Union[types.Float32, types.Int32]] = None
+    weight: typing.Union[None, types.Float32, types.Int32] = None
     is_student: bool = True
     encoded: bytes = b"Hi"
 """
@@ -145,6 +147,9 @@ import typing
 
 
 class FavoriteColor(enum.Enum):
+    \"""
+    A favorite color
+    \"""
     BLUE = "Blue"
     YELLOW = "Yellow"
     GREEN = "Green"
@@ -182,11 +187,11 @@ import typing
 
 @dataclasses.dataclass
 class Address(AvroModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
-
-    class Meta:
-        schema_doc = "An Address"
 
 
 @dataclasses.dataclass
@@ -212,11 +217,11 @@ import typing
 
 @dataclasses.dataclass
 class Address(AvroModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
-
-    class Meta:
-        schema_doc = "An Address"
 
 
 @dataclasses.dataclass
@@ -241,11 +246,11 @@ import typing
 
 @dataclasses.dataclass
 class Address(AvroModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
-
-    class Meta:
-        schema_doc = "An Address"
 
 
 @dataclasses.dataclass
@@ -261,7 +266,7 @@ class User(AvroModel):
     assert result.strip() == expected_result.strip()
 
 
-def test_schema_one_to_self_relathionship(schema_one_to_self_relationship: types.JsonDict) -> None:
+def test_schema_one_to_self_relationship(schema_one_to_self_relationship: types.JsonDict) -> None:
     expected_result = """
 from dataclasses_avroschema import AvroModel
 import dataclasses
@@ -272,9 +277,9 @@ import typing
 class User(AvroModel):
     name: str
     age: int
-    friend: typing.Optional[typing.Type["User"]] = None
-    relatives: typing.List[typing.Type["User"]] = dataclasses.field(default_factory=list)
-    teammates: typing.Dict[str, typing.Type["User"]] = dataclasses.field(default_factory=dict)
+    friend: typing.Optional["User"] = None
+    relatives: typing.List["User"] = dataclasses.field(default_factory=list)
+    teammates: typing.Dict[str, "User"] = dataclasses.field(default_factory=dict)
 """
     model_generator = ModelGenerator()
     result = model_generator.render(schema=schema_one_to_self_relationship)
@@ -346,6 +351,9 @@ import dataclasses
 
 @dataclasses.dataclass
 class User(AvroModel):
+    \"""
+    An User
+    \"""
     age: types.Int32
     weight: types.Int32
     money_available: float
@@ -357,17 +365,17 @@ class User(AvroModel):
 
     class Meta:
         namespace = "test"
-        schema_doc = "An User"
         aliases = ['schema', 'test-schema']
 
 
 @dataclasses.dataclass
 class Address(AvroModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
 
-    class Meta:
-        schema_doc = "An Address"
 """
     model_generator = ModelGenerator()
     result = model_generator.render_module(schemas=[schema, schema_2])

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -10,11 +10,11 @@ import typing
 
 
 class Address(BaseModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
-
-    class Meta:
-        schema_doc = "An Address"
 
 
 
@@ -41,9 +41,9 @@ import typing
 class User(BaseModel):
     name: str
     age: int
-    friend: typing.Optional[typing.Type["User"]] = None
-    relatives: typing.List[typing.Type["User"]] = Field(default_factory=list)
-    teammates: typing.Dict[str, typing.Type["User"]] = Field(default_factory=dict)
+    friend: typing.Optional["User"] = None
+    relatives: typing.List["User"] = Field(default_factory=list)
+    teammates: typing.Dict[str, "User"] = Field(default_factory=dict)
 """
     model_generator = ModelGenerator(base_class=BaseClassEnum.PYDANTIC_MODEL.value)
     result = model_generator.render(schema=schema_one_to_self_relationship)
@@ -58,11 +58,11 @@ import typing
 
 
 class Address(AvroBaseModel):
+    \"""
+    An Address
+    \"""
     street: str
     street_number: int
-
-    class Meta:
-        schema_doc = "An Address"
 
 
 
@@ -89,9 +89,9 @@ import typing
 class User(AvroBaseModel):
     name: str
     age: int
-    friend: typing.Optional[typing.Type["User"]] = None
-    relatives: typing.List[typing.Type["User"]] = Field(default_factory=list)
-    teammates: typing.Dict[str, typing.Type["User"]] = Field(default_factory=dict)
+    friend: typing.Optional["User"] = None
+    relatives: typing.List["User"] = Field(default_factory=list)
+    teammates: typing.Dict[str, "User"] = Field(default_factory=dict)
 """
     model_generator = ModelGenerator(base_class=BaseClassEnum.AVRO_DANTIC_MODEL.value)
     result = model_generator.render(schema=schema_one_to_self_relationship)

--- a/tests/schemas/test_faust.py
+++ b/tests/schemas/test_faust.py
@@ -63,7 +63,7 @@ def test_faust_record_schema_complex_types_with_defaults(user_advance_with_defau
 
 
 def test_faust_record_schema_logical_types(logical_types_schema):
-    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
+    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
 
     class LogicalTypes(faust.Record, AvroModel):
         "Some logical types"

--- a/tests/schemas/test_pydantic.py
+++ b/tests/schemas/test_pydantic.py
@@ -75,7 +75,7 @@ def test_pydantic_record_schema_complex_types_with_defaults(user_advance_with_de
 
 
 def test_pydantic_record_schema_logical_types(logical_types_schema):
-    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
+    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
 
     class LogicalTypes(AvroBaseModel):
         "Some logical types"

--- a/tests/schemas/test_roundtrip.py
+++ b/tests/schemas/test_roundtrip.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dataclasses_avroschema import BaseClassEnum, ModelGenerator
+
+here = Path(__file__).parent.absolute()
+
+marks = {
+    "union_type": [
+        pytest.mark.xfail(raises=RuntimeError, reason="model generator borks on difficult union namespaces")
+    ],
+    "decimal": [
+        pytest.mark.xfail(raises=ValueError, reason="model generator looses decimal precision for default-null fields")
+    ],
+    "user_with_field_metadata": [
+        pytest.mark.xfail(raises=AssertionError, reason="model generator does not support metadata yet")
+    ],
+    "union_default_type": [
+        pytest.mark.xfail(raises=AssertionError, reason="schema generator does not handle enum comments yet")
+    ],
+    "user_self_reference_one_to_many": [
+        pytest.mark.xfail(raises=AssertionError, reason="schema generator does not handle self references correctly")
+    ],
+    "user_self_reference_one_to_many_map": [
+        pytest.mark.xfail(raises=ValueError, reason="schema generator does not handle self references correctly")
+    ],
+    "user_self_reference_one_to_one": [
+        pytest.mark.xfail(raises=ValueError, reason="schema generator does not handle self references correctly")
+    ],
+}
+
+avsc_files = [pytest.param(f, id=f.stem, marks=marks.get(f.stem, ())) for f in here.glob("avro/*.avsc")]
+
+
+@pytest.mark.parametrize("schema", list(BaseClassEnum))
+@pytest.mark.parametrize("filename", avsc_files)
+def test_roundtrip(filename: Path, schema: BaseClassEnum):
+    model_generator = ModelGenerator()
+    schema = json.loads(filename.read_text())
+    result = model_generator.render(schema=schema)
+
+    try:
+        code = compile(result, filename.with_suffix(".py").name, "exec")
+    except Exception as e:
+        raise RuntimeError(f"Failed to compile {filename}:\n" + result) from e
+
+    ns = {}
+    try:
+        eval(code, ns)
+    except Exception as e:
+        raise RuntimeError(f"Failed to evaluate {filename}:\n" + result) from e
+    assert True
+
+    obj = ns[schema["name"]]
+    new_schema = obj.avro_schema_to_python()
+    assert new_schema == schema

--- a/tests/schemas/test_schema.py
+++ b/tests/schemas/test_schema.py
@@ -39,13 +39,13 @@ def test_schema_render_from_instance(user_dataclass, user_avro_json):
 
 
 def test_schema_render_from_class_with_doc(user_dataclass_with_doc, user_avro_json):
-    user_avro_json["doc"] = "User(name: str, age: int, has_pets: bool, money: float, encoded: bytes)"
+    user_avro_json["doc"] = "I am documented."
 
     assert user_dataclass_with_doc.avro_schema() == json.dumps(user_avro_json)
 
 
 def test_schema_render_from_instance_with_doc(user_dataclass_with_doc, user_avro_json):
-    user_avro_json["doc"] = "User(name: str, age: int, has_pets: bool, money: float, encoded: bytes)"
+    user_avro_json["doc"] = "I am documented."
     user = user_dataclass_with_doc("test", 20, True, 10.4, encoded)
 
     assert user.avro_schema() == json.dumps(user_avro_json)
@@ -325,14 +325,20 @@ def test_avro_schema_to_python_method_with_inheritance(user_avro_json: JsonDict)
 def test_avro_schema_method_with_inheritance() -> None:
     @dataclass
     class Common(AvroModel):
+        """Common docs"""
+
         some_data: str
 
     @dataclass
     class DerivedA(Common):
+        """DerivedA docs"""
+
         some_more_data_A: str
 
     @dataclass
     class DerivedB(Common):
+        """DerivedB docs"""
+
         some_more_data_B: str
 
     common_schema = Common.avro_schema()
@@ -341,13 +347,13 @@ def test_avro_schema_method_with_inheritance() -> None:
 
     assert (
         common_schema
-        == '{"type": "record", "name": "Common", "fields": [{"name": "some_data", "type": "string"}], "doc": "Common(some_data: str)"}'
+        == '{"type": "record", "name": "Common", "fields": [{"name": "some_data", "type": "string"}], "doc": "Common docs"}'
     )
     assert (
         derived_a_schema
-        == '{"type": "record", "name": "DerivedA", "fields": [{"name": "some_data", "type": "string"}, {"name": "some_more_data_A", "type": "string"}], "doc": "DerivedA(some_data: str, some_more_data_A: str)"}'
+        == '{"type": "record", "name": "DerivedA", "fields": [{"name": "some_data", "type": "string"}, {"name": "some_more_data_A", "type": "string"}], "doc": "DerivedA docs"}'
     )
     assert (
         derived_b_schema
-        == '{"type": "record", "name": "DerivedB", "fields": [{"name": "some_data", "type": "string"}, {"name": "some_more_data_B", "type": "string"}], "doc": "DerivedB(some_data: str, some_more_data_B: str)"}'
+        == '{"type": "record", "name": "DerivedB", "fields": [{"name": "some_data", "type": "string"}, {"name": "some_more_data_B", "type": "string"}], "doc": "DerivedB docs"}'
     )

--- a/tests/schemas/test_schema_with_logical_types.py
+++ b/tests/schemas/test_schema_with_logical_types.py
@@ -10,7 +10,7 @@ def test_logical_types_schema(logical_types_schema):
     """
     Test a schema with Logical Types
     """
-    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
+    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
 
     class LogicalTypes(AvroModel):
         "Some logical types"
@@ -26,7 +26,7 @@ def test_logical_micro_types_schema(logical_types_micro_schemas):
     """
     Test a schema with Logical Types
     """
-    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
+    a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
 
     class LogicalTypesMicro(AvroModel):
         "Some logical types"


### PR DESCRIPTION
fix: correctly generate type annotations

fix: do not generate default dataclass docstrings

fix: datetime model generation

the previous implementation did not roundtrip

feat: render docstrings in generated classes

fix: correct union and optional conversion

test: add avsc -> python -> avsc roundtrip test

fix: properly handle aliases in the model generator

tests: add coverage for single-type unions model generation