### PR TITLE
Fix type annotations for AvroBaseModel methods: `fake` and `parse_obj`

### DIFF
--- a/dataclasses_avroschema/avrodantic.py
+++ b/dataclasses_avroschema/avrodantic.py
@@ -35,11 +35,11 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
         return validate(self.asdict(), schema)
 
     @classmethod
-    def parse_obj(cls: Type["AvroBaseModel"], data: Dict) -> "AvroBaseModel":
+    def parse_obj(cls: Type[CT], data: Dict) -> CT:
         return super().parse_obj(data)
 
     @classmethod
-    def fake(cls: Type[CT], **data: Dict[str, Any]) -> "AvroBaseModel":
+    def fake(cls: Type[CT], **data: Dict[str, Any]) -> CT:
         """
         Creates a fake instance of the model.
 

--- a/dataclasses_avroschema/schema_definition.py
+++ b/dataclasses_avroschema/schema_definition.py
@@ -8,7 +8,7 @@ from dataclasses_avroschema import utils
 from dataclasses_avroschema.fields import AvroField, FieldType
 
 
-@dataclasses.dataclass  # type: ignore
+@dataclasses.dataclass
 class BaseSchemaDefinition(abc.ABC):
     """
     Minimal Schema definition
@@ -80,7 +80,7 @@ class AvroSchemaDefinition(BaseSchemaDefinition):
                 dataclass_field.name,
                 dataclass_field.type,
                 default=dataclass_field.default,
-                default_factory=dataclass_field.default_factory,  # type: ignore  # TODO: resolve mypy
+                default_factory=dataclass_field.default_factory,
                 metadata=dict(dataclass_field.metadata),
                 model_metadata=self.metadata,
                 parent=self.parent,

--- a/dataclasses_avroschema/types.py
+++ b/dataclasses_avroschema/types.py
@@ -7,7 +7,7 @@ import typing
 if sys.version_info >= (3, 9):
     from typing import Annotated
 else:
-    from typing_extensions import Annotated  # type: ignore # pragma: no cover
+    from typing_extensions import Annotated  # pragma: no cover
 
 if sys.version_info >= (3, 10):
     from types import UnionType  # pragma: no cover
@@ -19,10 +19,10 @@ JsonDict = typing.Dict[str, typing.Any]
 
 
 class FieldInfo:
-    def __init__(self, **kwargs) -> None:
-        self.type = kwargs.get("type")
-        self.max_digits = kwargs.get("max_digits", -1)
-        self.decimal_places = kwargs.get("decimal_places", 0)
+    def __init__(self, type: str, max_digits: int = -1, decimal_places: int = 0) -> None:
+        self.type = type
+        self.max_digits = max_digits
+        self.decimal_places = decimal_places
 
     def __repr__(self) -> str:
         return f"FieldInfo(type='{self.type}', max_digits={self.max_digits}, decimal_places={self.decimal_places})"
@@ -54,7 +54,7 @@ class Fixed(typing.Generic[T]):
         return f"{self.size}"
 
 
-def condecimal(*, max_digits, decimal_places) -> typing.Type[decimal.Decimal]:
+def condecimal(*, max_digits: int, decimal_places: int) -> typing.Type[decimal.Decimal]:
     return Annotated[  # type: ignore[return-value]
         decimal.Decimal, FieldInfo(type="Decimal", max_digits=max_digits, decimal_places=decimal_places)
     ]

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover
 
 try:
     import pydantic  # pragma: no cover
-except ImportError:  # type: ignore # pragma: no cover
+except ImportError:  # pragma: no cover
     pydantic = None  # type: ignore # pragma: no cover
 
 
@@ -65,7 +65,7 @@ def is_self_referenced(a_type: type) -> bool:
     return (
         isinstance(a_type, typing._GenericAlias)  # type: ignore
         and a_type.__args__
-        and isinstance(a_type.__args__[0], typing.ForwardRef)  # type: ignore
+        and isinstance(a_type.__args__[0], typing.ForwardRef)
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,15 @@ line-length = 120
 target_version = ['py37']
 
 [tool.mypy]
-allow_empty_bodies = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+strict_optional = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+disallow_any_generics = false
+exclude = ["tests", "examples"]
 
 [[tool.mypy.overrides]]
 module = "stringcase.*"


### PR DESCRIPTION
This PR addresses https://github.com/marcosschroh/dataclasses-avroschema/issues/299.
- I fixed incorrect types for AvroBaseModel.fake and AvroBaseModel.parse_obj.
- I also added more robust mypy configuration to the `pyproject.toml` (and also excluded tests and examples for now)
- Made some typing related tweaks to satisfy new errors based on the config
- Removed some `# type: ignore`s




