### PR TITLE
fix: Fix typo in kwargs typehint for AvroBaseModel.fake

### DIFF
--- a/dataclasses_avroschema/avrodantic.py
+++ b/dataclasses_avroschema/avrodantic.py
@@ -44,7 +44,7 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
         return validate(self.asdict(), schema)
 
     @classmethod
-    def fake(cls: Type[CT], **data: Dict[str, Any]) -> CT:
+    def fake(cls: Type[CT], **data: Any) -> CT:
         """
         Creates a fake instance of the model.
 


### PR DESCRIPTION
For arbitrary argument lists, only the value type is required, using Dict[str, Any] here was interpreted as Dict[str, Dict[str, Any]].