### PR TITLE
feat: support pydantic constrained int fields

### DIFF
--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -750,9 +750,7 @@ def field_factory(
     # special case for some dynamic pydantic types (especially constraint types)
     # when a type cannot be imported and needs to be referenced by qualified string
     # see pydantic conint() implementation for more information
-    elif (
-        inspect.isclass(native_type) and f"{native_type.__name__}" in INMUTABLE_FIELDS_CLASSES
-    ):
+    elif inspect.isclass(native_type) and f"{native_type.__name__}" in INMUTABLE_FIELDS_CLASSES:
         klass = INMUTABLE_FIELDS_CLASSES[f"{native_type.__name__}"]
         return klass(
             name=name,

--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -746,6 +746,24 @@ def field_factory(
             model_metadata=model_metadata,
             parent=parent,
         )
+
+    # special case for some dynamic pydantic types (especially constraint types)
+    # when a type cannot be imported and needs to be referenced by qualified string
+    # see pydantic conint() implementation for more information
+    elif (
+        inspect.isclass(native_type) and f"{native_type.__module__}.{native_type.__name__}" in INMUTABLE_FIELDS_CLASSES
+    ):
+        klass = INMUTABLE_FIELDS_CLASSES[f"{native_type.__module__}.{native_type.__name__}"]
+        return klass(
+            name=name,
+            type=native_type,
+            default=default,
+            default_factory=default_factory,
+            metadata=metadata,
+            model_metadata=model_metadata,
+            parent=parent,
+        )
+
     elif utils.is_self_referenced(native_type):
         return SelfReferenceField(
             name=name,

--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -751,9 +751,9 @@ def field_factory(
     # when a type cannot be imported and needs to be referenced by qualified string
     # see pydantic conint() implementation for more information
     elif (
-        inspect.isclass(native_type) and f"{native_type.__module__}.{native_type.__name__}" in INMUTABLE_FIELDS_CLASSES
+        inspect.isclass(native_type) and f"{native_type.__name__}" in INMUTABLE_FIELDS_CLASSES
     ):
-        klass = INMUTABLE_FIELDS_CLASSES[f"{native_type.__module__}.{native_type.__name__}"]
+        klass = INMUTABLE_FIELDS_CLASSES[f"{native_type.__name__}"]
         return klass(
             name=name,
             type=native_type,

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -74,6 +74,10 @@ try:
         pydantic.PositiveFloat: pydantic_fields.PositiveFloatField,
         pydantic.NegativeInt: pydantic_fields.NegativeIntField,
         pydantic.PositiveInt: pydantic_fields.PositiveIntField,
+        pydantic.ConstrainedInt: pydantic_fields.ConstrainedIntField,
+        # ConstrainedIntValue is a dynamic type that needs to be referenced by qualified name
+        # and cannot be imported directly
+        "pydantic.types.ConstrainedIntValue": pydantic_fields.ConstrainedIntField,
     }
 
     PYDANTIC_LOGICAL_TYPES_FIELDS_CLASSES = {
@@ -108,6 +112,7 @@ try:
         pydantic.PositiveFloat,
         pydantic.NegativeInt,
         pydantic.PositiveInt,
+        pydantic.ConstrainedInt,
         pydantic.UUID1,
         pydantic.UUID3,
         pydantic.UUID4,

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -8,7 +8,7 @@ from dataclasses_avroschema import types
 
 from . import fields, pydantic_fields
 
-INMUTABLE_FIELDS_CLASSES = {
+INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
     bool: fields.BooleanField,
     int: fields.LongField,
     types.Int32: fields.IntField,
@@ -77,7 +77,7 @@ try:
         pydantic.ConstrainedInt: pydantic_fields.ConstrainedIntField,
         # ConstrainedIntValue is a dynamic type that needs to be referenced by qualified name
         # and cannot be imported directly
-        "pydantic.types.ConstrainedIntValue": pydantic_fields.ConstrainedIntField,
+        "ConstrainedIntValue": pydantic_fields.ConstrainedIntField,
     }
 
     PYDANTIC_LOGICAL_TYPES_FIELDS_CLASSES = {

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -8,7 +8,7 @@ from dataclasses_avroschema import types
 
 from . import fields, pydantic_fields
 
-INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
+INMUTABLE_FIELDS_CLASSES: dict[typing.Union[type, str], type] = {
     bool: fields.BooleanField,
     int: fields.LongField,
     types.Int32: fields.IntField,

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import datetime
 import decimal
@@ -8,7 +10,7 @@ from dataclasses_avroschema import types
 
 from . import fields, pydantic_fields
 
-INMUTABLE_FIELDS_CLASSES: dict[typing.Union[type, str], type] = {
+INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
     bool: fields.BooleanField,
     int: fields.LongField,
     types.Int32: fields.IntField,

--- a/dataclasses_avroschema/fields/pydantic_fields.py
+++ b/dataclasses_avroschema/fields/pydantic_fields.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from dataclasses_avroschema.faker import fake
 
 from . import fields
-from .field_utils import DOUBLE, LONG, STRING, UUID
+from .field_utils import DOUBLE, INT, LONG, STRING, UUID
 
 current_file = str(Path(__file__).absolute())
 current_dir = str(Path().absolute())
@@ -19,7 +19,7 @@ class PydanticField(fields.ImmutableField):
 
 
 class FilePathField(PydanticField):
-    avro_type: typing.ClassVar[typing.Dict[str, str]] = {"type": STRING, "pydantic-class": "FilePat"}
+    avro_type: typing.ClassVar[typing.Dict[str, str]] = {"type": STRING, "pydantic-class": "FilePath"}
 
     def fake(self) -> str:
         return current_file
@@ -209,3 +209,12 @@ class UUID5Field(fields.UUIDField):
 
     def fake(self) -> uuid.UUID:
         return uuid.uuid5(namespace=uuid.NAMESPACE_URL, name=fake.pystr())
+
+
+class ConstrainedIntField(PydanticField):
+    @property
+    def avro_type(self) -> typing.Dict:
+        return {"type": INT, "pydantic-class": "ConstrainedInt"}
+
+    def fake(self) -> int:
+        return 1

--- a/docs/pydantic.md
+++ b/docs/pydantic.md
@@ -109,6 +109,7 @@ using the key `pydantic-class`.
 | double       | pydantic.PositiveFloat |
 | long         | pydantic.NegativeInt |
 | long         | pydantic.PositiveIntstr |
+| long         | pydantic.ConstrainedInt (conint) |
 
 | Avro Type    | Logical type | Pydantic Type |
 |--------------|--------------|---------------|
@@ -237,6 +238,7 @@ class Infrastructure(AvroBaseModel):
 | double    | "pydantic-class": "PositiveFloat"  | pydantic.PositiveFloat |
 | long      | "pydantic-class": "NegativeInt"    | pydantic.NegativeInt |
 | long      | "pydantic-class": "PositiveInt"    | pydantic.PositiveInt |
+| long      | "pydantic-class": ConstrainedInt"  | pydantic.ConstrainedInt |
 
 |Avro Type  | Logical Type | Metadata | Pydantic Type                      |
 |-----------|--------------|----------|------------------------------------|

--- a/tests/fake/const.py
+++ b/tests/fake/const.py
@@ -23,6 +23,7 @@ pydantic_fields = (
     pydantic.PositiveFloat,
     pydantic.NegativeInt,
     pydantic.PositiveInt,
+    pydantic.ConstrainedInt,
     pydantic.UUID1,
     pydantic.UUID3,
     pydantic.UUID4,

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -25,7 +25,7 @@ PRIMITIVE_TYPES = (
     (Annotated[float, "float"], field_utils.DOUBLE),
     (Annotated[bytes, "bytes"], field_utils.BYTES),
     # pydantic fields
-    (pydantic.FilePath, {"type": field_utils.STRING, "pydantic-class": "FilePat"}),
+    (pydantic.FilePath, {"type": field_utils.STRING, "pydantic-class": "FilePath"}),
     (pydantic.DirectoryPath, {"type": field_utils.STRING, "pydantic-class": "DirectoryPath"}),
     (pydantic.EmailStr, {"type": field_utils.STRING, "pydantic-class": "EmailStr"}),
     (pydantic.NameEmail, {"type": field_utils.STRING, "pydantic-class": "NameEmail"}),

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -473,3 +473,14 @@ def schema_with_pydantic_fields() -> JsonDict:
             },
         ],
     }
+
+
+@pytest.fixture
+def schema_with_pydantic_constrained_fields() -> JsonDict:
+    return {
+        "type": "record",
+        "name": "ConstrainedValues",
+        "fields": [
+            {"pydantic-class": "conint(gt=10, lt=20)", "name": "constrained_int", "type": "int"},
+        ],
+    }

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -180,3 +180,23 @@ class Infrastructure(AvroBaseModel):
     model_generator = ModelGenerator(base_class=BaseClassEnum.AVRO_DANTIC_MODEL.value)
     result = model_generator.render(schema=schema_with_pydantic_fields)
     assert result.strip() == expected_result.strip()
+
+
+def test_schema_with_pydantic_constrained_field(schema_with_pydantic_constrained_fields):
+    expected_result = """
+from dataclasses_avroschema import types
+from dataclasses_avroschema.avrodantic import AvroBaseModel
+import pydantic
+
+
+
+class ConstrainedValues(AvroBaseModel):
+    constrained_int: pydantic.conint(gt=10, lt=20)
+
+
+
+"""
+
+    model_generator = ModelGenerator(base_class=BaseClassEnum.AVRO_DANTIC_MODEL.value)
+    result = model_generator.render(schema=schema_with_pydantic_constrained_fields)
+    assert result.strip() == expected_result.strip()

--- a/tests/serialization/test_pydantic_fields.py
+++ b/tests/serialization/test_pydantic_fields.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import Field
+from pydantic.error_wrappers import ValidationError
+
+from dataclasses_avroschema.avrodantic import AvroBaseModel
+
+
+def test_int_constraint_type_serialize():
+    class ConstraintType(AvroBaseModel):
+        value: int = Field(gt=0)
+
+    c = ConstraintType(value=1)
+    serialized = c.serialize(serialization_type="avro-json")
+    assert serialized == b'{"value": 1}'
+
+
+def test_int_constraint_type_deserialize():
+    class ConstraintType(AvroBaseModel):
+        value: int = Field(gt=0)
+
+    ConstraintType.deserialize(b'{"value": 1}', serialization_type="avro-json")
+
+
+def test_int_constraint_type_deserialize_invalid():
+    class ConstraintType(AvroBaseModel):
+        value: int = Field(gt=0)
+
+    with pytest.raises(ValidationError):
+        ConstraintType.deserialize(b'{"value": 0}', serialization_type="avro-json")

--- a/tests/serialization/test_pydantic_fields.py
+++ b/tests/serialization/test_pydantic_fields.py
@@ -1,29 +1,29 @@
 import pytest
-from pydantic import Field
+from pydantic import Field, conint
 from pydantic.error_wrappers import ValidationError
 
 from dataclasses_avroschema.avrodantic import AvroBaseModel
 
 
-def test_int_constraint_type_serialize():
-    class ConstraintType(AvroBaseModel):
-        value: int = Field(gt=0)
+def test_int_constrained_type_serialize():
+    class ConstrainedType(AvroBaseModel):
+        value: conint(gt=0)
 
-    c = ConstraintType(value=1)
+    c = ConstrainedType(value=1)
     serialized = c.serialize(serialization_type="avro-json")
     assert serialized == b'{"value": 1}'
 
 
-def test_int_constraint_type_deserialize():
-    class ConstraintType(AvroBaseModel):
-        value: int = Field(gt=0)
+def test_int_constrained_type_deserialize():
+    class ConstrainedType(AvroBaseModel):
+        value: conint(gt=0)
 
-    ConstraintType.deserialize(b'{"value": 1}', serialization_type="avro-json")
+    ConstrainedType.deserialize(b'{"value": 1}', serialization_type="avro-json")
 
 
-def test_int_constraint_type_deserialize_invalid():
-    class ConstraintType(AvroBaseModel):
+def test_int_constrained_type_deserialize_invalid():
+    class ConstrainedType(AvroBaseModel):
         value: int = Field(gt=0)
 
     with pytest.raises(ValidationError):
-        ConstraintType.deserialize(b'{"value": 0}', serialization_type="avro-json")
+        ConstrainedType.deserialize(b'{"value": 0}', serialization_type="avro-json")


### PR DESCRIPTION
Add pydantic `conint()` dynamic type support to allow schemas to use custom value constraints:

```
 class ConstraintType(AvroBaseModel):
        value: int = Field(gt=0)
```

This is initial PR to start discussion/approach - support for floats will come soon.