### PR TITLE
Resolve issues with raw `None` annotation

### DIFF
--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -742,6 +742,9 @@ def field_factory(
 
     field_info = None
 
+    if native_type is None:
+        native_type = type(None)
+
     if native_type not in types.CUSTOM_TYPES and utils.is_annotated(native_type):
         a_type, *extra_args = get_args(native_type)
         field_info = next((arg for arg in extra_args if isinstance(arg, types.FieldInfo)), None)

--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -128,6 +128,9 @@ class NoneField(ImmutableField):
     def avro_type(self) -> str:
         return field_utils.NULL
 
+    def get_avro_type(self) -> str:
+        return self.avro_type
+
 
 @dataclasses.dataclass
 class ContainerField(Field):

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -10,7 +10,7 @@ from dataclasses_avroschema import types
 
 from . import fields, pydantic_fields
 
-INMUTABLE_FIELDS_CLASSES: dict[type | str | None, type] = {
+INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
     bool: fields.BooleanField,
     int: fields.LongField,
     types.Int32: fields.IntField,
@@ -18,7 +18,6 @@ INMUTABLE_FIELDS_CLASSES: dict[type | str | None, type] = {
     types.Float32: fields.FloatField,
     bytes: fields.BytesField,
     str: fields.StringField,
-    None: fields.NoneField,
     type(None): fields.NoneField,
 }
 

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -10,7 +10,7 @@ from dataclasses_avroschema import types
 
 from . import fields, pydantic_fields
 
-INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
+INMUTABLE_FIELDS_CLASSES: dict[type | str | None, type] = {
     bool: fields.BooleanField,
     int: fields.LongField,
     types.Int32: fields.IntField,
@@ -18,6 +18,7 @@ INMUTABLE_FIELDS_CLASSES: dict[type | str, type] = {
     types.Float32: fields.FloatField,
     bytes: fields.BytesField,
     str: fields.StringField,
+    None: fields.NoneField,
     type(None): fields.NoneField,
 }
 

--- a/tests/fields/consts.py
+++ b/tests/fields/consts.py
@@ -19,6 +19,8 @@ PRIMITIVE_TYPES = (
     (bool, field_utils.BOOLEAN),
     (float, field_utils.DOUBLE),
     (bytes, field_utils.BYTES),
+    (None, field_utils.NULL),
+    (type(None), field_utils.NULL),
     (Annotated[str, "string"], field_utils.STRING),
     (Annotated[int, "integer"], field_utils.LONG),
     (Annotated[bool, "boolean"], field_utils.BOOLEAN),
@@ -55,6 +57,8 @@ PRIMITIVE_TYPES_AND_DEFAULTS = (
     (bool, True),
     (float, 10.4),
     (bytes, b"test"),
+    (None, None),
+    (type(None), None),
     (Annotated[str, "string"], "test"),
     (Annotated[int, "int"], 1),
     (Annotated[bool, "boolen"], True),
@@ -68,6 +72,8 @@ PRIMITIVE_TYPES_AND_INVALID_DEFAULTS = (
     (bool, 10),
     (float, False),
     (bytes, "test"),
+    (None, 1),
+    (type(None), "test"),
 )
 
 LOGICAL_TYPES = (

--- a/tests/fields/test_complex_types.py
+++ b/tests/fields/test_complex_types.py
@@ -390,7 +390,10 @@ def test_union_as_optional_with_primitives(primitive_type, avro_type) -> None:
     python_type = typing.Optional[primitive_type]
     field = AvroField(name, python_type)
 
-    expected = {"name": name, "type": [avro_type, "null"]}
+    if python_type is type(None):
+        expected = {"name": name, "type": "null"}
+    else:
+        expected = {"name": name, "type": [avro_type, "null"]}
 
     assert expected == field.to_dict()
 

--- a/tests/fields/test_primitive_types.py
+++ b/tests/fields/test_primitive_types.py
@@ -23,7 +23,11 @@ def test_primitive_types(primitive_type):
 def test_primitive_types_with_default_value_none(primitive_type):
     name = "a_field"
     field = AvroField(name, primitive_type, default=None)
-    avro_type = [field_utils.NULL, field.avro_type]
+
+    if field.avro_type == field_utils.NULL:
+        avro_type = field_utils.NULL
+    else:
+        avro_type = [field_utils.NULL, field.avro_type]
 
     assert {"name": name, "type": avro_type, "default": None} == field.to_dict()
 
@@ -56,6 +60,9 @@ def test_primitive_types_with_default_factory_value(primitive_type, default):
 def test_invalid_default_values(primitive_type, invalid_default):
     name = "a_field"
     field = AvroField(name, primitive_type, default=invalid_default)
+
+    if primitive_type is None:
+        primitive_type = type(None)
 
     msg = f"Invalid default type. Default should be {primitive_type}"
     with pytest.raises(AssertionError, match=msg):


### PR DESCRIPTION
Resolves #424.

While working on the fix, I noticed some typos and minor issues:

- `readme.md` - To run tests locally, one should run `poetry install --all-extras`. Otherwise, tests will fail because `pydantic` is not installed.
- Common typo I**N**MUTABLE. Present in definitions in `dataclasses_avroschema/fields/mapper.py` and `tests/fields/test_primitive_types.py`.
- `tests/fields/consts.py` - tuple `PRIMITIVE_TYPES_AND_DEFAULTS` has member with `Annotated[bool, "boolen"]`. `a` is missing.

Should/may I also fix these problems?

