### PR TITLE
fix: add fake() support to Literal field type

### DIFF
--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -365,6 +365,9 @@ class LiteralField(Field):
     def validate_default(self, default: typing.Any) -> bool:
         return self.avro_field.validate_default(default)  # type: ignore
 
+    def fake(self) -> typing.Any:
+        return random.choice(get_args(self.type))
+
 
 @dataclasses.dataclass
 class FixedField(BytesField):

--- a/tests/schemas/test_pydantic.py
+++ b/tests/schemas/test_pydantic.py
@@ -439,6 +439,7 @@ def test_fake(color_enum) -> None:
         favorite_colors: color_enum = color_enum.BLUE
         country: str = "Argentina"
         address: typing.Optional[Address] = None
+        role: typing.Literal["admin", "user"] = "user"
 
     # just calling fake is enougt to know that a proper instance was created,
     # otherwise a pydantic validation should have been raised


### PR DESCRIPTION
Support for the `Literal` type added in #435 was missing a `fake()` definition. Added a simple one to pick a random input arg, and also added usage in the pydantic tests which would catch it.
