### PR TITLE
Fix kwarg typing in AvroModel

### DIFF
--- a/dataclasses_avroschema/schema_generator.py
+++ b/dataclasses_avroschema/schema_generator.py
@@ -158,7 +158,7 @@ class AvroModel:
         # and after that convert into python
         return self.asdict()
 
-    def to_json(self, **kwargs) -> str:
+    def to_json(self, **kwargs: Any) -> str:
         data = serialization.to_json(self.asdict())
         return json.dumps(data, **kwargs)
 
@@ -191,12 +191,13 @@ class AvroModel:
         return config
 
     @classmethod
-    def fake(cls: Type[CT], **data: Dict[str, Any]) -> CT:
+    def fake(cls: Type[CT], **data: Any) -> CT:
         """
         Creates a fake instance of the model.
 
-        Attributes:
-            data: Dict[str, Any] represent the user values to use in the instance
+        Keyword Arguments:
+            Any user values to use in the instance. All fields not explicitly passed
+            will be filled with fake data.
         """
         # only generate fakes for fields that were not provided in data
         payload = {field.name: field.fake() for field in cls.get_fields() if field.name not in data.keys()}


### PR DESCRIPTION
Annotations for `*args`, `**kwargs` indicate the type of the values, not the structure Python passes back. See [PEP 484](https://peps.python.org/pep-0484/) for full details, but the relevant part is this:

> [...] the annotation here denotes the type of the individual argument values, not of the tuple/dict that you receive as the special argument value `args` or `kwds`.

A screenshot from PyCharm with an example:

<img width="621" alt="Screenshot 2023-12-08 at 3 03 25 PM" src="https://github.com/dargueta-copilotiq/dataclasses-avroschema/assets/136350469/92abf69e-ec7a-4154-bb6f-87602832ad9d">
