### PR TITLE
fix: bump inflector version for python3.12 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2287,4 +2287,4 @@ pydantic = ["pydantic"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e81303bcbf70b75979f10ac712ea7a21af68c1ab502ec72a5a0f8525cfa522f2"
+content-hash = "5bc45436326bbd463b75a8556896125a300a30ceb19c66977d8f6616be4083d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python = "^3.8"
 fastavro = "^1.7.3"
 dacite = "^1.8.0"
 faker = {version = ">=18.3.1,<23.0.0", optional = true}
-inflector = "^3.1.0"
+inflector = "^3.1.1"
 faust-streaming = {version = "^0.10.11", optional = true}
 casefy = "^0.1.7"
 typing-extensions = {version = "^4.2.0", python = "<3.9"}


### PR DESCRIPTION
Ref from this issue https://github.com/ixmatus/inflector/issues/15, removes syntax warnings for python3.12