### PR TITLE
Fix: Fix incorrect casing when rendering fields and enums 

### DIFF
--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -488,6 +488,10 @@ class EnumField(Field):
     def get_avro_type(self) -> typing.Union[str, types.JsonDict]:
         metadata = self._get_meta_class_attributes()
         name = self.type.__name__
+        # If the enum name in avro schema different than the python enum class name, use the schema_name.
+        if "schema_name" in metadata:
+            name = metadata.get("schema_name")
+            metadata.pop("schema_name")
 
         if not self.exist_type():
             user_defined_type = utils.UserDefinedType(name=name, type=self.type)

--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -487,11 +487,8 @@ class EnumField(Field):
 
     def get_avro_type(self) -> typing.Union[str, types.JsonDict]:
         metadata = self._get_meta_class_attributes()
-        name = self.type.__name__
         # If the enum name in avro schema different than the python enum class name, use the schema_name.
-        if "schema_name" in metadata:
-            name = metadata.get("schema_name")
-            metadata.pop("schema_name")
+        name = metadata.pop("schema_name", self.type.__name__)
 
         if not self.exist_type():
             user_defined_type = utils.UserDefinedType(name=name, type=self.type)

--- a/dataclasses_avroschema/model_generator/lang/python/base.py
+++ b/dataclasses_avroschema/model_generator/lang/python/base.py
@@ -196,7 +196,7 @@ class BaseGenerator:
             docstring=docstring,
         )
 
-        add_schema_name = not name == schema["name"]
+        add_schema_name = name != schema["name"]
         class_metadata = self.render_metaclass(schema=schema, field_order=field_order, add_schema_name=add_schema_name)
         if class_metadata is not None:
             rendered_class += class_metadata
@@ -460,7 +460,7 @@ class BaseGenerator:
 
         docstring = self.render_docstring(docstring=field.get("doc"))
         enum_class = templates.enum_template.safe_substitute(name=enum_name, symbols=symbols_repr, docstring=docstring)
-        add_schema_name = not enum_name == field["name"]
+        add_schema_name = enum_name != field["name"]
         metaclass = self.render_metaclass(
             schema=field,
             decorator=templates.METACLASS_DECORATOR,

--- a/dataclasses_avroschema/model_generator/lang/python/base.py
+++ b/dataclasses_avroschema/model_generator/lang/python/base.py
@@ -134,7 +134,9 @@ class BaseGenerator:
             )
 
         if add_schema_name:
-            metadata.append(self.metadata_field_templates["schema_name"].safe_substitute(name="schema_name", value=schema["name"]))
+            metadata.append(
+                self.metadata_field_templates["schema_name"].safe_substitute(name="schema_name", value=schema["name"])
+            )
 
         properties = self.field_identation.join(metadata)
 
@@ -459,7 +461,11 @@ class BaseGenerator:
         docstring = self.render_docstring(docstring=field.get("doc"))
         enum_class = templates.enum_template.safe_substitute(name=enum_name, symbols=symbols_repr, docstring=docstring)
         add_schema_name = not enum_name == field["name"]
-        metaclass = self.render_metaclass(schema=field, decorator=templates.METACLASS_DECORATOR, add_schema_name=add_schema_name)
+        metaclass = self.render_metaclass(
+            schema=field,
+            decorator=templates.METACLASS_DECORATOR,
+            add_schema_name=add_schema_name,
+        )
 
         if metaclass:
             enum_class += metaclass

--- a/dataclasses_avroschema/model_generator/lang/python/base.py
+++ b/dataclasses_avroschema/model_generator/lang/python/base.py
@@ -429,7 +429,7 @@ class BaseGenerator:
         We need a template for it in order to create the Enum
         """
         self.imports.add("import enum")
-        enum_name: str = field["name"]
+        enum_name: str = casefy.pascalcase(field["name"])
 
         symbols_map = {}
         symbols: typing.List[str] = field["symbols"]
@@ -490,7 +490,7 @@ class BaseGenerator:
             # it means the type points to the an already specified type so it contains the type name
             # with optional namespaces, e.g. my_namespace.users.User
             # In this case we should return the last part of the string
-            return type.split(".")[-1]
+            return casefy.pascalcase(type.split(".")[-1])
         elif default is not None:
             return str(self.avro_type_to_lang.get(type, default))
         else:
@@ -577,7 +577,7 @@ class BaseGenerator:
         ):
             default_repr = f'b"{default}"'
         elif field_type == field_utils.ENUM:
-            default_repr = f"{name}.{casefy.uppercase(default)}"
+            default_repr = f"{casefy.pascalcase(name)}.{casefy.uppercase(default)}"
         elif isinstance(field_type, list):
             # union type
             default_repr = self.get_field_default(field_type=field_type[0], default=default, name=name)

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -121,6 +121,7 @@ class FieldMetadata:
     aliases: typing.List[str] = dataclasses.field(default_factory=list)
     doc: typing.Optional[str] = None
     namespace: typing.Optional[str] = None
+    schema_name: typing.Optional[str] = None
 
     @classmethod
     def create(cls: typing.Type["FieldMetadata"], klass: typing.Optional[type]) -> "FieldMetadata":
@@ -129,6 +130,7 @@ class FieldMetadata:
             doc=getattr(klass, "doc", None),
             namespace=getattr(klass, "namespace", None),
             default=getattr(klass, "default", dataclasses.MISSING),
+            schema_name=getattr(klass, "schema_name", None),
         )
 
     def to_dict(self) -> typing.Dict[str, typing.Union[typing.List[str], str]]:

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -235,7 +235,7 @@ def schema_with_enum_types() -> Dict:
                 },
             },
             {
-                "name": "primaty_color",
+                "name": "primary_color",
                 "type": "some.name.space.FavoriteColor",
             },
             {
@@ -356,7 +356,7 @@ def schema_with_enum_types_no_pascal_case() -> Dict:
                     "aliases": ["Color", "My favorite color"],
                 },
             },
-            {"name": "primaty_color", "type": "some.name.space.my_favorite_color"},
+            {"name": "primary_color", "type": "some.name.space.my_favorite_color"},
             {
                 "name": "superheros",
                 "type": {"type": "enum", "name": "super_heros", "symbols": ["batman", "superman", "spiderman"]},

--- a/tests/model_generator/test_model_generator.py
+++ b/tests/model_generator/test_model_generator.py
@@ -234,7 +234,7 @@ class Cars({templates.ENUM_PYTHON_VERSION}):
 @dataclasses.dataclass
 class User(AvroModel):
     favorite_color: FavoriteColor
-    primaty_color: FavoriteColor
+    primary_color: FavoriteColor
     superheros: Superheros = Superheros.BATMAN
     cars: typing.Optional[Cars] = None
 """
@@ -348,14 +348,17 @@ import dataclasses
 import enum
 
 
-class unit_multi_player({templates.ENUM_PYTHON_VERSION}):
+class UnitMultiPlayer({templates.ENUM_PYTHON_VERSION}):
     q = "q"
     Q = "Q"
 
+    {templates.METACLASS_DECORATOR}
+    class Meta:
+        schema_name = "unit_multi_player"
 
 @dataclasses.dataclass
 class User(AvroModel):
-    unit_multi_player: unit_multi_player
+    unit_multi_player: UnitMultiPlayer
 
 """
     model_generator = ModelGenerator()
@@ -371,7 +374,7 @@ import enum
 import typing
 
 
-class my_favorite_color({templates.ENUM_PYTHON_VERSION}):
+class MyFavoriteColor({templates.ENUM_PYTHON_VERSION}):
     """
     A favorite color
     """
@@ -383,25 +386,32 @@ class my_favorite_color({templates.ENUM_PYTHON_VERSION}):
     class Meta:
         namespace = "some.name.space"
         aliases = ['Color', 'My favorite color']
+        schema_name = "my_favorite_color"
 
-class super_heros({templates.ENUM_PYTHON_VERSION}):
+class SuperHeros({templates.ENUM_PYTHON_VERSION}):
     BATMAN = "batman"
     SUPERMAN = "superman"
     SPIDERMAN = "spiderman"
 
+    {templates.METACLASS_DECORATOR}
+    class Meta:
+        schema_name = "super_heros"
 
-class cars({templates.ENUM_PYTHON_VERSION}):
+class Cars({templates.ENUM_PYTHON_VERSION}):
     BMW = "bmw"
     FERRARY = "ferrary"
     DUNA = "duna"
 
+    {templates.METACLASS_DECORATOR}
+    class Meta:
+        schema_name = "cars"
 
 @dataclasses.dataclass
 class User(AvroModel):
-    favorite_color: my_favorite_color
-    primaty_color: my_favorite_color
-    superheros: super_heros = super_heros.BATMAN
-    my_cars: typing.Optional[cars] = None
+    favorite_color: MyFavoriteColor
+    primary_color: MyFavoriteColor
+    superheros: SuperHeros = SuperHeros.BATMAN
+    my_cars: typing.Optional[Cars] = None
 '''
     model_generator = ModelGenerator()
     result = model_generator.render(schema=schema_with_enum_types_no_pascal_case)
@@ -534,6 +544,11 @@ import dataclasses
 @dataclasses.dataclass
 class Demo(AvroModel):
     foo: types.condecimal(max_digits=10, decimal_places=3)
+
+    
+    class Meta:
+        schema_name = "demo"
+
 """
     model_generator = ModelGenerator()
     result = model_generator.render(schema=schema_with_decimal_field)

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -2,7 +2,6 @@ from dataclasses_avroschema import ModelGenerator, ModelType, types
 from dataclasses_avroschema.fields import field_utils
 from dataclasses_avroschema.model_generator.lang.python.avro_to_python_utils import (
     render_datetime,
-    templates,
 )
 
 
@@ -186,7 +185,7 @@ class Message(AvroBaseModel):
 
 
 def test_decimal_field(schema_with_decimal_field: types.JsonDict) -> None:
-    expected_result = f"""
+    expected_result = """
 from dataclasses_avroschema import types
 from dataclasses_avroschema.pydantic import AvroBaseModel
 
@@ -195,7 +194,7 @@ from dataclasses_avroschema.pydantic import AvroBaseModel
 class Demo(AvroBaseModel):
     foo: types.condecimal(max_digits=10, decimal_places=3)
 
-    {templates.METACLASS_DECORATOR}
+    
     class Meta:
         schema_name = "demo"
 """

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -2,6 +2,7 @@ from dataclasses_avroschema import ModelGenerator, ModelType, types
 from dataclasses_avroschema.fields import field_utils
 from dataclasses_avroschema.model_generator.lang.python.avro_to_python_utils import (
     render_datetime,
+    templates,
 )
 
 
@@ -185,7 +186,7 @@ class Message(AvroBaseModel):
 
 
 def test_decimal_field(schema_with_decimal_field: types.JsonDict) -> None:
-    expected_result = """
+    expected_result = f"""
 from dataclasses_avroschema import types
 from dataclasses_avroschema.pydantic import AvroBaseModel
 
@@ -193,6 +194,10 @@ from dataclasses_avroschema.pydantic import AvroBaseModel
 
 class Demo(AvroBaseModel):
     foo: types.condecimal(max_digits=10, decimal_places=3)
+
+    {templates.METACLASS_DECORATOR}
+    class Meta:
+        schema_name = "demo"
 """
     model_generator = ModelGenerator()
     result = model_generator.render(schema=schema_with_decimal_field, model_type=ModelType.AVRODANTIC.value)


### PR DESCRIPTION
Fixes https://github.com/marcosschroh/dataclasses-avroschema/issues/693 https://github.com/marcosschroh/dataclasses-avroschema/issues/692
This change fixed incorrect case rendering of fields inside a record which has the same record type and uses a reference of the type to determine the type of the field. Since the field name is converted to Pascal case for Record types, the reference type name should also be Pascal cased.
The Enum class rendering has a similar issue where the default value of the enum field does not contain the Pascal case of the Enum class.