### PR TITLE
fix: Always reuse the rendered type when type is same

### DIFF
--- a/dataclasses_avroschema/fields/base.py
+++ b/dataclasses_avroschema/fields/base.py
@@ -129,7 +129,7 @@ class Field:
         same_types = [
             field.type
             for field in self.parent._user_defined_types
-            if field.type == self.type and field.name != self.name
+            if field.type == self.type
         ]
 
         # If length > 0, means that it is the first appearance

--- a/tests/schemas/avro/user_advance_with_duplicate_field_names.avsc
+++ b/tests/schemas/avro/user_advance_with_duplicate_field_names.avsc
@@ -1,0 +1,53 @@
+{
+    "type": "record",
+    "name": "UserDetails",
+    "fields": [
+        {
+            "name": "address",
+            "type": {
+                "type": "record",
+                "name": "address",
+                "fields": [
+                    {
+                        "name": "streetaddress",
+                        "type": "string"
+                    },
+                    {
+                        "name": "city",
+                        "type": {
+                            "type": "record",
+                            "name": "city",
+                            "fields": [
+                                {
+                                    "name": "city_name",
+                                    "type": "string"
+                                },
+                                {
+                                    "name": "zip_code",
+                                    "type": "int"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "work_location",
+            "type": {
+                "type": "record",
+                "name": "work_location",
+                "fields": [
+                    {
+                        "name": "company_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "city",
+                        "type": "city"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
During avro_schema_to_python() call if two fields in different child fields of a class has same type and name, reuse the rendered field in the schema instead of re-rendering.

Fixes https://github.com/marcosschroh/dataclasses-avroschema/issues/709

### Testing

Added a new round trip test with the nested fields in schema.
