### PR TITLE
feat(AvroBaseModel): non-deprecated pydantic v2 custom fields

### DIFF
--- a/dataclasses_avroschema/__init__.py
+++ b/dataclasses_avroschema/__init__.py
@@ -32,6 +32,7 @@ from .fields.fields import (
     BooleanField,
     BytesField,
     ContainerField,
+    CustomAvroEncoder,
     DateField,
     DatetimeField,
     DatetimeMicroField,
@@ -63,6 +64,7 @@ from .types import DateTimeMicro, Float32, Int32, TimeMicro, condecimal, confixe
 
 __all__ = [
     "AvroModel",
+    "CustomAvroEncoder",
     "BaseClassEnum",
     "ModelType",
     "ModelGenerator",

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -32,6 +32,13 @@ def is_pydantic_model(klass: typing.Type) -> bool:
 
 
 @lru_cache(maxsize=None)
+def is_pydantic_v2_model(klass: typing.Type) -> bool:
+    if pydantic is not None:
+        return issubclass(klass, pydantic.BaseModel)
+    return False
+
+
+@lru_cache(maxsize=None)
 def is_faust_record(klass: typing.Type) -> bool:
     if faust is not None:
         return issubclass(klass, faust.Record)


### PR DESCRIPTION
Add a new way to generate Avro schema and serialize custom fields for Pydantic v2 `AvroBaseModel`s. This new strategy provides a `CustomAvroEncoder` class to use as an annotation on fields with types that don't natively support serialization to Avro. The existing Pydantic v2 custom serialization/schema-generation strategy depends on the `json_encoders` model config, which is deprecated.

My only usecase for this is so I can serialize `timedelta`s to `float` seconds in my models without having to depend on deprecated Pydantic functionality (and without having to write a custom `__get_pydantic_core_schema__`, because this is natively supported by Pydantic). If there's a better way to do this that I missed, please let me know (and thank you for your time)!