### PR TITLE
feat: support timedelta serialization to `double` seconds

### DIFF
--- a/dataclasses_avroschema/fields/field_utils.py
+++ b/dataclasses_avroschema/fields/field_utils.py
@@ -30,6 +30,7 @@ __all__ = [
     "LOGICAL_TIME_MICROS",
     "LOGICAL_DATETIME_MILIS",
     "LOGICAL_DATETIME_MICROS",
+    "LOGICAL_TIMEDELTA",
     "LOGICAL_UUID",
     "PYTHON_TYPE_TO_AVRO",
 ]
@@ -38,6 +39,7 @@ TIME_MILLIS = "time-millis"
 TIME_MICROS = "time-micros"
 TIMESTAMP_MILLIS = "timestamp-millis"
 TIMESTAMP_MICROS = "timestamp-micros"
+TIMEDELTA = "dataclasses-avroschema-timedelta"
 
 BOOLEAN = "boolean"
 NULL = "null"
@@ -60,6 +62,7 @@ LOGICAL_TIME_MILIS = {"type": INT, "logicalType": TIME_MILLIS}
 LOGICAL_TIME_MICROS = {"type": LONG, "logicalType": TIME_MICROS}
 LOGICAL_DATETIME_MILIS = {"type": LONG, "logicalType": TIMESTAMP_MILLIS}
 LOGICAL_DATETIME_MICROS = {"type": LONG, "logicalType": TIMESTAMP_MICROS}
+LOGICAL_TIMEDELTA = {"type": DOUBLE, "logicalType": TIMEDELTA}
 LOGICAL_UUID = {"type": STRING, "logicalType": UUID}
 
 AVRO_TYPES = (

--- a/dataclasses_avroschema/fields/mapper.py
+++ b/dataclasses_avroschema/fields/mapper.py
@@ -37,6 +37,7 @@ LOGICAL_TYPES_FIELDS_CLASSES = {
     datetime.time: fields.TimeMilliField,
     types.TimeMicro: fields.TimeMicroField,
     datetime.datetime: fields.DatetimeField,
+    datetime.timedelta: fields.TimedeltaField,
     types.DateTimeMicro: fields.DatetimeMicroField,
     uuid.uuid4: fields.UUIDField,
     uuid.UUID: fields.UUIDField,

--- a/dataclasses_avroschema/model_generator/lang/python/avro_to_python_utils.py
+++ b/dataclasses_avroschema/model_generator/lang/python/avro_to_python_utils.py
@@ -19,12 +19,14 @@ AVRO_TYPE_TO_PYTHON: typing.Dict[str, str] = {
     field_utils.TIME_MICROS: "types.TimeMicro",
     field_utils.TIMESTAMP_MILLIS: "datetime.datetime",
     field_utils.TIMESTAMP_MICROS: "types.DateTimeMicro",
+    field_utils.TIMEDELTA: "datetime.timedelta",
     field_utils.UUID: "uuid.UUID",
 }
 
 LOGICAL_TYPES_IMPORTS: typing.Dict[str, str] = {
     field_utils.DECIMAL: "import decimal",
     field_utils.DATE: "import datetime",
+    field_utils.TIMEDELTA: "import datetime",
     field_utils.TIME_MILLIS: "import datetime",
     field_utils.TIME_MICROS: "from dataclasses_avroschema import types",
     field_utils.TIMESTAMP_MILLIS: "import datetime",
@@ -41,6 +43,7 @@ LOGICAL_TYPES_TO_PYTHON = {
     field_utils.TIMESTAMP_MICROS: lambda value: datetime.datetime.fromtimestamp(
         value / 1000000, tz=datetime.timezone.utc
     ),
+    field_utils.TIMEDELTA: lambda value: datetime.timedelta(seconds=value),
 }
 
 # Logical types objects to template
@@ -73,6 +76,9 @@ LOGICAL_TYPE_TEMPLATES = {
         minute=datetime_obj.minute,
         second=datetime_obj.second,
         microsecond=datetime_obj.microsecond,
+    ),
+    field_utils.TIMEDELTA: lambda timedelta_obj: templates.timedelta_template.safe_substitute(
+        seconds=timedelta_obj.total_seconds(),
     ),
 }
 

--- a/dataclasses_avroschema/model_generator/lang/python/templates.py
+++ b/dataclasses_avroschema/model_generator/lang/python/templates.py
@@ -23,6 +23,7 @@ DATETIME_TEMPLATE = "datetime.datetime($year, $month, $day, $hour, $minute, $sec
 DATETIME_MICROS_TEMPLATE = (
     "datetime.datetime($year, $month, $day, $hour, $minute, $second, $microsecond, tzinfo=datetime.timezone.utc)"
 )
+TIMEDELTA_TEMPLATE = "datetime.timedelta(seconds=$seconds)"
 DECIMAL_TEMPLATE = "decimal.Decimal('$value')"
 DECIMAL_TYPE_TEMPLATE = "types.condecimal(max_digits=$precision, decimal_places=$scale)"
 
@@ -85,5 +86,6 @@ time_template = Template(TIME_TEMPLATE)
 time_micros_template = Template(TIME_MICROS_TEMPLATE)
 datetime_template = Template(DATETIME_TEMPLATE)
 datetime_micros_template = Template(DATETIME_MICROS_TEMPLATE)
+timedelta_template = Template(TIMEDELTA_TEMPLATE)
 imports_template = Template(IMPORTS_TEMPLATE.strip())
 module_template = Template(MODULE_TEMPLATE.strip())

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -249,6 +249,8 @@ def serialize_value(*, value: typing.Any) -> typing.Any:
         value = date_to_str(value)
     elif isinstance(value, datetime.time):
         value = time_to_str(value)
+    elif isinstance(value, datetime.timedelta):
+        value = value.total_seconds()
     elif isinstance(value, (uuid.UUID, decimal.Decimal)):
         value = str(value)
     elif isinstance(value, dict):

--- a/docs/logical_types.md
+++ b/docs/logical_types.md
@@ -9,6 +9,7 @@ The following list represent the avro logical types mapped to python types:
 | long      |  time-micros | types.TimeMicro |
 | long      |  timestamp-millis | datetime.datetime |
 | long      |  timestamp-micros | types.DateTimeMicro |
+| double    |  timedelta   | datetime.timedelta |
 | string    |  uuid        | uuid.uuid4 |
 | string    |  uuid        | uuid.UUID |
 | bytes     | decimal      | types.condecimal |
@@ -170,6 +171,44 @@ DatetimeLogicalType.avro_schema()
 
 !!! note
     To use `timestamp-micros` in avro schemas you need to use `types.DateTimeMicro`
+
+## Timedelta
+
+`timedelta` fields are serialized to a `double` number of seconds.
+
+```python title="Timedelta example"
+import datetime
+import dataclasses
+
+from dataclasses_avroschema import AvroModel
+
+delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
+
+@dataclasses.dataclass
+class TimedeltaLogicalType(AvroModel):
+    "Timedelta logical type"
+    time_elapsed: datetime.timedelta = delta
+
+DatetimeLogicalType.avro_schema()
+
+'{
+  "type": "record",
+  "name": "DatetimeLogicalType",
+  "fields": [
+    {
+      "name": "time_elapsed",
+      "type": {
+        "type": "double",
+        "logicalType": "dataclasses-avroschema-timedelta"
+      },
+      "default": 788645.006007
+    }
+  ],
+  "doc": "Timedelta logical type"
+}'
+```
+
+*(This script is complete, it should run "as is")*
 
 ## UUID
 

--- a/tests/fake/test_fake.py
+++ b/tests/fake/test_fake.py
@@ -54,6 +54,7 @@ def test_fake_with_logical_types() -> None:
         meeting_time_micro: types.TimeMicro
         release_datetime: datetime.datetime
         release_datetime_micro: types.DateTimeMicro
+        time_elapsed: datetime.timedelta
         event_uuid: uuid.UUID
 
     assert isinstance(LogicalTypes.fake(), LogicalTypes)

--- a/tests/fake/test_fake_pydantic.py
+++ b/tests/fake/test_fake_pydantic.py
@@ -19,6 +19,7 @@ def test_fake_with_logical_types() -> None:
         meeting_time_micro: types.TimeMicro
         release_datetime: datetime.datetime
         release_datetime_micro: types.DateTimeMicro
+        time_elapsed: datetime.timedelta
         event_uuid: uuid.UUID
 
     assert isinstance(LogicalTypes.fake(), LogicalTypes)

--- a/tests/fake/test_fake_pydantic_v1.py
+++ b/tests/fake/test_fake_pydantic_v1.py
@@ -19,6 +19,7 @@ def test_fake_with_logical_types() -> None:
         meeting_time_micro: types.TimeMicro
         release_datetime: datetime.datetime
         release_datetime_micro: types.DateTimeMicro
+        time_elapsed: datetime.timedelta
         event_uuid: uuid.UUID
 
     assert isinstance(LogicalTypes.fake(), LogicalTypes)

--- a/tests/fields/test_logical_types.py
+++ b/tests/fields/test_logical_types.py
@@ -154,6 +154,25 @@ def test_logical_type_datetime_with_default() -> None:
     assert expected == field_with_default_factory.to_dict()
 
 
+def test_logical_type_timedelta_with_default() -> None:
+    name = "a timedelta"
+    python_type = datetime.timedelta
+    delta = datetime.timedelta(seconds=1.234567)
+    seconds = delta.total_seconds()
+
+    field = AvroField(name, python_type, default=delta)
+    field_with_default_factory = AvroField(name, python_type, default_factory=lambda: delta)
+
+    expected = {
+        "name": name,
+        "type": {"type": field_utils.DOUBLE, "logicalType": field_utils.TIMEDELTA},
+        "default": seconds,
+    }
+
+    assert expected == field.to_dict()
+    assert expected == field_with_default_factory.to_dict()
+
+
 @pytest.mark.parametrize(
     "python_type,avro_type",
     (

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -960,6 +960,11 @@ def schema_with_logical_types() -> JsonDict:
                 "default": 1570903062000000,
             },
             {
+                "name": "time_elapsed",
+                "type": {"type": "double", "logicalType": "dataclasses-avroschema-timedelta"},
+                "default": 788645.006007,
+            },
+            {
                 "name": "uuid_2",
                 "type": ["null", {"type": "string", "logicalType": "uuid"}],
                 "default": None,

--- a/tests/model_generator/test_model_generator.py
+++ b/tests/model_generator/test_model_generator.py
@@ -793,6 +793,7 @@ class LogicalTypes(AvroModel):
     meeting_datetime: typing.Optional[datetime.datetime] = None
     release_datetime: datetime.datetime = {release_datetime}
     release_datetime_micro: types.DateTimeMicro = {release_datetime_micro}
+    time_elapsed: datetime.timedelta = datetime.timedelta(seconds=788645.006007)
     uuid_2: typing.Optional[uuid.UUID] = None
     event_uuid: uuid.UUID = "ad0677ab-bd1c-4383-9d45-e46c56bcc5c9"
     explicit_with_default: types.condecimal(max_digits=3, decimal_places=2) = decimal.Decimal('3.14')

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -235,6 +235,7 @@ class LogicalTypes(AvroBaseModel):
     meeting_datetime: typing.Optional[datetime.datetime] = None
     release_datetime: datetime.datetime = {release_datetime}
     release_datetime_micro: types.DateTimeMicro = {release_datetime_micro}
+    time_elapsed: datetime.timedelta = datetime.timedelta(seconds=788645.006007)
     uuid_2: typing.Optional[uuid.UUID] = None
     event_uuid: uuid.UUID = "ad0677ab-bd1c-4383-9d45-e46c56bcc5c9"
     explicit_with_default: types.condecimal(max_digits=3, decimal_places=2) = decimal.Decimal('3.14')

--- a/tests/schemas/avro/logical_types.avsc
+++ b/tests/schemas/avro/logical_types.avsc
@@ -27,6 +27,14 @@
         "default": 1570903062000
       },
       {
+        "name": "time_elapsed",
+        "type": {
+          "type": "double",
+          "logicalType": "dataclasses-avroschema-timedelta"
+        },
+        "default": 788645.006007
+      },
+      {
         "name": "event_uuid",
         "type": {
           "type": "string",
@@ -37,4 +45,4 @@
     ],
     "doc": "Some logical types"
   }
-  
+

--- a/tests/schemas/avro/logical_types_pydantic.avsc
+++ b/tests/schemas/avro/logical_types_pydantic.avsc
@@ -81,6 +81,14 @@
             "default": 1570903062000
         },
         {
+          "name": "time_elapsed",
+          "type": {
+            "type": "double",
+            "logicalType": "dataclasses-avroschema-timedelta"
+          },
+          "default": 788645.006007
+        },
+        {
             "name": "event_uuid",
             "type": {
                 "type": "string",

--- a/tests/schemas/avro/union_type.avsc
+++ b/tests/schemas/avro/union_type.avsc
@@ -11,6 +11,7 @@
       "type": [
         {"type": "long", "logicalType": "timestamp-millis"},
         {"type": "int", "logicalType": "date"},
+        {"type": "double", "logicalType": "dataclasses-avroschema-timedelta"},
         {"type": "string", "logicalType": "uuid"}
       ]
     },

--- a/tests/schemas/pydantic/test_pydantic.py
+++ b/tests/schemas/pydantic/test_pydantic.py
@@ -150,6 +150,7 @@ def test_pydantic_record_schema_logical_types(logical_types_pydantic_schema):
     a_past_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
     a_future_datetime = datetime.datetime(9999, 12, 31, 23, 59, 59)
     a_naive_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42)
+    delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
 
     class LogicalTypesPydantic(AvroBaseModel):
         "Some logical types"
@@ -163,6 +164,7 @@ def test_pydantic_record_schema_logical_types(logical_types_pydantic_schema):
         future_datetime: FutureDatetime = a_future_datetime
         aware_datetime: AwareDatetime = a_datetime
         naive_datetime: NaiveDatetime = a_naive_datetime
+        time_elapsed: datetime.timedelta = delta
         event_uuid: uuid.UUID = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert LogicalTypesPydantic.avro_schema() == json.dumps(logical_types_pydantic_schema)
@@ -337,7 +339,7 @@ def test_pydantic_record_schema_with_unions_type(union_type_schema):
         "Some Unions"
 
         first_union: typing.Union[str, int]
-        logical_union: typing.Union[datetime.datetime, datetime.date, uuid.UUID]
+        logical_union: typing.Union[datetime.datetime, datetime.date, datetime.timedelta, uuid.UUID]
         lake_trip: typing.Union[Bus, Car]
         river_trip: typing.Union[Bus, Car] = None
         mountain_trip: typing.Union[Bus, Car] = Field(default_factory=lambda: Bus(engine_name="honda"))

--- a/tests/schemas/pydantic/test_pydantic_v1.py
+++ b/tests/schemas/pydantic/test_pydantic_v1.py
@@ -109,6 +109,7 @@ def test_pydantic_record_schema_complex_types_with_defaults(user_advance_with_de
 
 def test_pydantic_record_schema_logical_types(logical_types_schema):
     a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
+    delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
 
     class LogicalTypes(AvroBaseModel):
         "Some logical types"
@@ -116,6 +117,7 @@ def test_pydantic_record_schema_logical_types(logical_types_schema):
         birthday: datetime.date = a_datetime.date()
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
+        time_elapsed: datetime.timedelta = delta
         event_uuid: uuid.UUID = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert LogicalTypes.avro_schema() == json.dumps(logical_types_schema)
@@ -290,7 +292,7 @@ def test_pydantic_record_schema_with_unions_type(union_type_schema):
         "Some Unions"
 
         first_union: typing.Union[str, int]
-        logical_union: typing.Union[datetime.datetime, datetime.date, uuid.UUID]
+        logical_union: typing.Union[datetime.datetime, datetime.date, datetime.timedelta, uuid.UUID]
         lake_trip: typing.Union[Bus, Car]
         river_trip: typing.Union[Bus, Car] = None
         mountain_trip: typing.Union[Bus, Car] = Field(default_factory=lambda: Bus(engine_name="honda"))

--- a/tests/schemas/test_fastavro_paser_schema.py
+++ b/tests/schemas/test_fastavro_paser_schema.py
@@ -351,6 +351,9 @@ def test_logical_types_schema():
         birthday: datetime.date = a_datetime.date()
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
+        time_elapsed: datetime.timedelta = datetime.timedelta(
+            weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7
+        )
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert parse_schema(LogicalTypes.avro_schema_to_python())

--- a/tests/schemas/test_faust.py
+++ b/tests/schemas/test_faust.py
@@ -65,6 +65,7 @@ def test_faust_record_schema_complex_types_with_defaults(user_advance_with_defau
 
 def test_faust_record_schema_logical_types(logical_types_schema):
     a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
+    delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
 
     class LogicalTypes(AvroRecord):
         "Some logical types"
@@ -72,6 +73,7 @@ def test_faust_record_schema_logical_types(logical_types_schema):
         birthday: datetime.date = a_datetime.date()
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
+        time_elapsed: datetime.timedelta = delta
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert LogicalTypes.avro_schema() == json.dumps(logical_types_schema)

--- a/tests/schemas/test_roundtrip.py
+++ b/tests/schemas/test_roundtrip.py
@@ -45,6 +45,7 @@ def test_roundtrip(filename: Path, timezone: ZoneInfo):
     model_generator = ModelGenerator(base_class=base_class)
     schema = json.loads(filename.read_text())
     result = model_generator.render(schema=schema)
+    print(result)
 
     try:
         code = compile(result, filename.with_suffix(".py").name, "exec")

--- a/tests/schemas/test_schema_with_complex_types.py
+++ b/tests/schemas/test_schema_with_complex_types.py
@@ -57,7 +57,7 @@ def test_schema_with_unions_type(union_type_schema: JsonDict) -> None:
         "Some Unions"
 
         first_union: typing.Union[str, int]
-        logical_union: typing.Union[datetime.datetime, datetime.date, uuid.uuid4]
+        logical_union: typing.Union[datetime.datetime, datetime.date, datetime.timedelta, uuid.uuid4]
         lake_trip: typing.Union[Bus, Car]
         river_trip: typing.Optional[typing.Union[Bus, Car]] = None
         mountain_trip: typing.Union[Bus, Car] = dataclasses.field(default_factory=lambda: Bus(engine_name="honda"))
@@ -146,7 +146,7 @@ def test_schema_with_new_unions_type_syntax(union_type_schema: JsonDict) -> None
         "Some Unions"
 
         first_union: str | int
-        logical_union: datetime.datetime | datetime.date | uuid.UUID
+        logical_union: datetime.datetime | datetime.date | datetime.timedelta | uuid.UUID
         lake_trip: Bus | Car
         river_trip: Bus | Car | None = None
         mountain_trip: Bus | Car = dataclasses.field(default_factory=lambda: Bus(engine_name="honda"))  # type: ignore

--- a/tests/schemas/test_schema_with_logical_types.py
+++ b/tests/schemas/test_schema_with_logical_types.py
@@ -12,6 +12,7 @@ def test_logical_types_schema(logical_types_schema):
     Test a schema with Logical Types
     """
     a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
+    delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
 
     class LogicalTypes(AvroModel):
         "Some logical types"
@@ -19,6 +20,7 @@ def test_logical_types_schema(logical_types_schema):
         birthday: datetime.date = a_datetime.date()
         meeting_time: datetime.time = a_datetime.time()
         release_datetime: datetime.datetime = a_datetime
+        time_elapsed: datetime.timedelta = delta
         event_uuid: uuid.uuid4 = "09f00184-7721-4266-a955-21048a5cc235"
 
     assert LogicalTypes.avro_schema() == json.dumps(logical_types_schema)

--- a/tests/serialization/test_logical_types_serialization.py
+++ b/tests/serialization/test_logical_types_serialization.py
@@ -12,6 +12,7 @@ from dataclasses_avroschema.faust import AvroRecord
 from dataclasses_avroschema.pydantic import AvroBaseModel
 
 a_datetime = datetime.datetime(2019, 10, 12, 17, 57, 42, tzinfo=datetime.timezone.utc)
+delta = datetime.timedelta(weeks=1, days=2, hours=3, minutes=4, seconds=5, milliseconds=6, microseconds=7)
 
 
 parametrize_base_model = pytest.mark.parametrize(
@@ -30,6 +31,7 @@ def test_logical_types(model_class: typing.Type[AvroModel], decorator: typing.Ca
         meeting_time_micro: types.TimeMicro
         release_datetime: datetime.datetime
         release_datetime_micro: types.DateTimeMicro
+        time_elapsed: datetime.timedelta
         event_uuid: uuid.UUID
 
     data = {
@@ -38,6 +40,7 @@ def test_logical_types(model_class: typing.Type[AvroModel], decorator: typing.Ca
         "meeting_time_micro": a_datetime.time(),
         "release_datetime": a_datetime,
         "release_datetime_micro": a_datetime,
+        "time_elapsed": delta,
         "event_uuid": uuid.UUID("09f00184-7721-4266-a955-21048a5cc235"),
     }
 
@@ -47,6 +50,7 @@ def test_logical_types(model_class: typing.Type[AvroModel], decorator: typing.Ca
         "meeting_time_micro": serialization.time_to_str(a_datetime.time()),
         "release_datetime": serialization.datetime_to_str(a_datetime),
         "release_datetime_micro": serialization.datetime_to_str(a_datetime),
+        "time_elapsed": 788645.006007,
         "event_uuid": "09f00184-7721-4266-a955-21048a5cc235",
     }
 


### PR DESCRIPTION
Serialize and deserialize Python `datetime.timedelta` fields to/from an Avro `double` number of seconds. 

This implements the `timedelta` serialization discussed in [this PR](https://github.com/marcosschroh/dataclasses-avroschema/pull/785). One difference from the solution discussed in that PR is that this uses `fastavro`'s [Custom Logical Types](https://fastavro.readthedocs.io/en/latest/logical_types.html#custom-logical-types) functionality, instead of doing the conversion in `standardize_custom_type`.