### PR TITLE
fix(TimedeltaField): fix timedelta fastavro serialization so it doesn't break in union types

### DIFF
--- a/tests/serialization/test_logical_types_serialization.py
+++ b/tests/serialization/test_logical_types_serialization.py
@@ -82,13 +82,16 @@ def test_logical_union(model_class: typing.Type[AvroModel], decorator: typing.Ca
         "Some Unions"
 
         logical_union: typing.Union[datetime.datetime, datetime.date, uuid.UUID]
+        logical_union_timedelta: typing.Union[datetime.timedelta, None]
 
     data = {
         "logical_union": a_datetime.date(),
+        "logical_union_timedelta": None,
     }
 
     data_json = {
         "logical_union": serialization.date_to_str(a_datetime.date()),
+        "logical_union_timedelta": None,
     }
 
     logical_types = UnionSchema(**data)


### PR DESCRIPTION
There is a bug in the [timedelta serialization](https://github.com/marcosschroh/dataclasses-avroschema/pull/793) that I contributed, sorry!

Fastavro [custom logical type encoders](https://fastavro.readthedocs.io/en/latest/logical_types.html#custom-logical-types) should explicitly check that they are operating on the expected python type before encoding it, and return the unchanged data otherwise. If a custom logical type is used as a member of a union type, then this encoder function will be called on any value that is provided for a field of that type, even if the value's type is a different member of the union type.

I have [PR that updates the Fastavro docs](https://github.com/fastavro/fastavro/pull/818) to clarify this. I think anyone implementing a custom logical type would always want this check, I'll see what they say.  In any case, I think we definitely need it here.