### PR TITLE
fix: support Python 3.13 in is_annotated

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup pythonß

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development",
 ]


### PR DESCRIPTION
In Python 3.13, the `typing.Annotated` type was changed to no longer support `isinstance` or `issubclass`. Replace the `is_annotated` implementation with code from Pydantic that checks to see if the origin of the type matches the `Annotated` type exported from either `typing` or `typing_extensions`.

Add Python 3.13 to the CI test matrix and to the library classifiers.

Fixes #816