### PR TITLE
fix(AvroRecord): deserialize properly union when they are encoded usi…

### DIFF
--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -152,7 +152,7 @@ def standardize_custom_type(
         if is_faust_record(type(value)):  # type: ignore[arg-type]
             # we need to do a trick because we can not overrride asdict from faust..
             # once the function interface is introduced we can remove this check
-            asdict = value.standardize_type(include_type=False)  # type: ignore
+            asdict = value.standardize_type(include_type=include_type)  # type: ignore
         else:
             asdict = value.asdict()
 

--- a/tests/serialization/test_nested_schema_serialization.py
+++ b/tests/serialization/test_nested_schema_serialization.py
@@ -271,7 +271,7 @@ def test_nested_schemas_splitted_with_unions(model_class: typing.Type[AvroModel]
 
     @decorator
     class S1(model_class):
-        ...
+        age: int = 10
 
         class Meta:
             namespace = "my_namespace"
@@ -302,15 +302,15 @@ def test_nested_schemas_splitted_with_unions(model_class: typing.Type[AvroModel]
     c2 = C(b=B(a=A(s=S1())), a=A(s=S2()))
 
     ser = b.serialize()
-    assert ser == b"\x00\x00"
+    assert ser == b"\x00\x00\x14"
     assert B.deserialize(ser) == b
 
     ser = c.serialize()
-    assert ser == b"\x00\x00\x00"
+    assert ser == b"\x00\x00\x14\x00\x14"
     assert C.deserialize(ser) == c
 
     ser = c2.serialize()
-    assert ser == b"\x00\x00\x02\x14"
+    assert ser == b"\x00\x00\x14\x02\x14"
     assert C.deserialize(ser) == c2
 
 


### PR DESCRIPTION
…ng avro-bynary. Related to #849