### PR TITLE
Refine return type of parse_obj and deserialize to be the current class

### DIFF
--- a/dataclasses_avroschema/main.py
+++ b/dataclasses_avroschema/main.py
@@ -2,7 +2,7 @@ import dataclasses
 import inspect
 import json
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Type, TypeVar, Union, overload
 
 from dacite import Config, from_dict
 from fastavro.validation import validate
@@ -16,7 +16,7 @@ from .utils import UserDefinedType, standardize_custom_type
 
 _schemas_cache: Dict["Type[AvroModel]", dict] = {}
 _dacite_config_cache: Dict["Type[AvroModel]", Config] = {}
-
+TSelf = TypeVar("TSelf", bound="AvroModel")
 
 class AvroModel:
     _parser: Optional[Parser] = None
@@ -128,13 +128,40 @@ class AvroModel:
         cls._parent = None
 
     @classmethod
+    @overload
     def deserialize(
-        cls: Type["AvroModel"],
+        cls: Type[TSelf],
         data: bytes,
-        serialization_type: serialization.SerializationType = "avro",
-        create_instance: bool = True,
-        writer_schema: Optional[Union[JsonDict, Type["AvroModel"]]] = None,
-    ) -> Union[JsonDict, "AvroModel"]:
+        serialization_type: serialization.SerializationType = ...,
+        create_instance: Literal[False] = ...,
+        writer_schema: Optional[Union[JsonDict, Type["AvroModel"]]] = ...,
+    ) -> JsonDict: ...
+    @classmethod
+    @overload
+    def deserialize(
+        cls: Type[TSelf],
+        data: bytes,
+        serialization_type: serialization.SerializationType = ...,
+        create_instance: Literal[True] = ...,
+        writer_schema: Optional[Union[JsonDict, Type["AvroModel"]]] = ...,
+    ) -> TSelf: ...
+    @classmethod
+    @overload
+    def deserialize(
+        cls: Type[TSelf],
+        data: bytes,
+        serialization_type: serialization.SerializationType = ...,
+        create_instance: bool = ...,
+        writer_schema: Optional[Union[JsonDict, Type["AvroModel"]]] = ...,
+    ) -> Union[TSelf, JsonDict]: ...
+    @classmethod
+    def deserialize(
+        cls,
+        data,
+        serialization_type="avro",
+        create_instance=True,
+        writer_schema=None,
+    ):
         payload = cls.deserialize_to_python(data, serialization_type, writer_schema)
         obj = cls.parse_obj(payload)
 
@@ -166,7 +193,7 @@ class AvroModel:
         )
 
     @classmethod
-    def parse_obj(cls: Type["AvroModel"], data: Dict) -> "AvroModel":
+    def parse_obj(cls: Type[TSelf], data: Dict) -> TSelf:
         config = _dacite_config_cache.get(cls)
         if config is None:
             config = generate_dacite_config(cls)


### PR DESCRIPTION
Nicer typing experience when using codegen and the `.deserialize` classmethod 😊

Before:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/750685ef-860e-44d7-b4b8-b74f48a5c92e" />
After:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/ba7d631e-454b-4ada-bab2-b90fdc283df4" />
