### PR TITLE
fix(ModelGenerator): Rename fields named after Python keywords. Closes #812

### DIFF
--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -63,6 +63,20 @@ def schema_with_invalid_python_identifiers() -> Dict:
 
 
 @pytest.fixture
+def schema_with_python_keywords() -> Dict:
+    return {
+        "type": "record",
+        "name": "Address",
+        "fields": [
+            {"name": "class", "type": "string"},
+            {"name": "yield", "type": "string", "aliases": ["yield"]},
+            {"name": "yield_class", "type": "long"},
+        ],
+        "doc": "An Address",
+    }
+
+
+@pytest.fixture
 def schema_primitive_types_as_defined_types() -> Dict:
     return {
         "type": "record",

--- a/tests/model_generator/test_model_pydantic_generator.py
+++ b/tests/model_generator/test_model_pydantic_generator.py
@@ -115,6 +115,28 @@ class Address(AvroBaseModel):
     assert result.strip() == expected_result.strip()
 
 
+def test_avro_pydantic_python_keywords(schema_with_python_keywords: types.JsonDict) -> None:
+    expected_result = """
+from dataclasses_avroschema.pydantic import AvroBaseModel
+import pydantic
+
+
+
+class Address(AvroBaseModel):
+    \"""
+    An Address
+    \"""
+    class_: str = pydantic.Field(metadata={'aliases': ['class']})
+    yield_: str = pydantic.Field(metadata={'aliases': ['yield']})
+    yield_class: int
+
+
+"""
+    model_generator = ModelGenerator()
+    result = model_generator.render(schema=schema_with_python_keywords, model_type=ModelType.AVRODANTIC.value)
+    assert result.strip() == expected_result.strip()
+
+
 def test_avro_pydantic_model_with_meta_fields(
     schema_one_to_self_relationship: types.JsonDict,
 ) -> None:


### PR DESCRIPTION
We now append an "_" to any fields that are Python keywords in order to still generate valid Python code.