### PR TITLE
Add an option to control inclusion of the `-type` field for `model.asdict()`

### DIFF
--- a/dataclasses_avroschema/main.py
+++ b/dataclasses_avroschema/main.py
@@ -216,10 +216,10 @@ class AvroModel:
 
         return from_dict(data_class=cls, data=payload, config=generate_dacite_config(cls))
 
-    def asdict(self) -> JsonDict:
+    def asdict(self, include_type: bool = True) -> JsonDict:
         return {
             field.name: standardize_custom_type(
-                field_name=field.name, value=getattr(self, field.name), model=self, base_class=AvroModel
+                field_name=field.name, value=getattr(self, field.name), model=self, base_class=AvroModel, include_type=include_type
             )
             for field in dataclasses.fields(self)  # type: ignore[arg-type]
         }

--- a/dataclasses_avroschema/pydantic/main.py
+++ b/dataclasses_avroschema/pydantic/main.py
@@ -36,7 +36,7 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
                 data[k] = encode_method(v)
         return data
 
-    def asdict(self) -> JsonDict:
+    def asdict(self, include_type: bool = True) -> JsonDict:
         """
         Returns this model in dictionary form. This method differs from
         pydantic's dict by converting all values to their Avro representation.
@@ -45,7 +45,7 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
         """
         return {
             field_name: standardize_custom_type(
-                field_name=field_name, value=field_value, model=self, base_class=AvroBaseModel
+                field_name=field_name, value=field_value, model=self, base_class=AvroBaseModel, include_type=include_type
             )
             for field_name, field_value in self._standardize_type().items()
         }

--- a/dataclasses_avroschema/pydantic/v1/main.py
+++ b/dataclasses_avroschema/pydantic/v1/main.py
@@ -35,7 +35,7 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
                 data[k] = encode_method(v)
         return data
 
-    def asdict(self) -> JsonDict:
+    def asdict(self, include_type: bool = True) -> JsonDict:
         """
         Returns this model in dictionary form. This method differs from
         pydantic's dict by converting all values to their Avro representation.
@@ -44,7 +44,7 @@ class AvroBaseModel(BaseModel, AvroModel):  # type: ignore
         """
         return {
             field_name: standardize_custom_type(
-                field_name=field_name, value=value, model=self, base_class=AvroBaseModel
+                field_name=field_name, value=value, model=self, base_class=AvroBaseModel, include_type=include_type
             )
             for field_name, value in self._standardize_type().items()
         }

--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -158,7 +158,7 @@ def standardize_custom_type(
             # once the function interface is introduced we can remove this check
             asdict = value.standardize_type(include_type=include_type)  # type: ignore
         else:
-            asdict = value.asdict()
+            asdict = value.asdict(include_type=include_type)
 
         annotations = model.__annotations__
         # This is a hack to get the annotations from the parent class


### PR DESCRIPTION
I have a use case to serialize `AvroModel` as dictionary without adding the `-type` field. 

#893 seems similar.

Not sure what will break by adding `include_type` to the `.asdict()` method, but it does seem to pass tests.