### PR TITLE
fix: bridge Pydantic decimal constraints

### DIFF
--- a/dataclasses_avroschema/pydantic/parser.py
+++ b/dataclasses_avroschema/pydantic/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import decimal
 import typing
 
 from pydantic.fields import FieldInfo
@@ -8,6 +9,7 @@ from pydantic.fields import FieldInfo
 from dataclasses_avroschema.fields.fields import AvroField
 from dataclasses_avroschema.parser import Parser
 from dataclasses_avroschema.protocol import FieldProtocol, ModelProtocol
+from dataclasses_avroschema.types import DecimalFieldInfo
 
 
 class PydanticParser(Parser):
@@ -40,11 +42,34 @@ class PydanticParser(Parser):
 
         return metadata
 
+    @staticmethod
+    def get_field_type(field_info: FieldInfo) -> typing.Any:
+        annotation = field_info.rebuild_annotation()
+        if field_info.annotation is decimal.Decimal:
+            decimal_info = next(
+                (
+                    item
+                    for item in field_info.metadata
+                    if getattr(item, "max_digits", None) is not None
+                    and getattr(item, "decimal_places", None) is not None
+                ),
+                None,
+            )
+            if decimal_info is not None:
+                annotation = typing.Annotated[
+                    annotation,
+                    DecimalFieldInfo(
+                        max_digits=decimal_info.max_digits,
+                        decimal_places=decimal_info.decimal_places,
+                    ),
+                ]
+        return annotation
+
     def parse_fields(self, exclude: typing.List) -> typing.List[FieldProtocol]:
         return [
             AvroField(
                 field_name,
-                field_info.rebuild_annotation(),
+                self.get_field_type(field_info),
                 default=dataclasses.MISSING
                 if field_info.is_required() or field_info.default_factory
                 else field_info.default,

--- a/tests/schemas/pydantic/test_pydantic.py
+++ b/tests/schemas/pydantic/test_pydantic.py
@@ -47,6 +47,23 @@ def test_pydantic_record_schema_primitive_types(user_avro_json):
     assert User.avro_schema() == json.dumps(user_avro_json)
 
 
+def test_pydantic_decimal_field_constraints():
+    class Transaction(AvroBaseModel):
+        amount: typing.Annotated[decimal.Decimal, Field(max_digits=9, decimal_places=2)]
+
+    assert Transaction.avro_schema_to_python()["fields"] == [
+        {
+            "name": "amount",
+            "type": {
+                "type": "bytes",
+                "logicalType": "decimal",
+                "precision": 9,
+                "scale": 2,
+            },
+        }
+    ]
+
+
 def test_exclude_default_from_schema(user_avro_json):
     class User(AvroBaseModel):
         name: str = Field(default="marcos", metadata={"exclude_default": True})


### PR DESCRIPTION
Closes #948

Pydantic stores native `max_digits` and `decimal_places` constraints in field metadata, but the Avro parser only recognized its own decimal metadata type. This bridges Pydantic's constraints into `DecimalFieldInfo`, so generated decimal schemas preserve the requested precision and scale.

Tested with the new regression plus the full Pydantic schema test module (32 passed), Ruff, formatting, and compilation checks.