### PR TITLE
fix: render null default as None in model generator

### DIFF
--- a/dataclasses_avroschema/model_generator/lang/python/base.py
+++ b/dataclasses_avroschema/model_generator/lang/python/base.py
@@ -122,6 +122,11 @@ class FieldRepresentation:
 
         if self.default is dataclasses.MISSING:
             ...
+        elif self.default is None:
+            # A `null` default is always rendered as `None`, regardless of the
+            # field type. Type specific converters (e.g. the logical type ones)
+            # cannot handle `None`.
+            default_repr = "None"
         elif self.avro_type in (
             field_utils.STRING,
             field_utils.UUID,

--- a/tests/model_generator/conftest.py
+++ b/tests/model_generator/conftest.py
@@ -1379,3 +1379,19 @@ def logical_types_not_nested() -> JsonDict:
         "name": "LogicalTypesNotNested",
         "fields": [{"name": "occurrence_date", "type": "long", "logicalType": "timestamp-millis"}],
     }
+
+
+@pytest.fixture
+def logical_types_not_nested_with_null_default() -> JsonDict:
+    return {
+        "type": "record",
+        "name": "LogicalTypesNotNestedWithNullDefault",
+        "fields": [
+            {
+                "name": "occurrence_date",
+                "type": ["null", "long"],
+                "logicalType": "timestamp-millis",
+                "default": None,
+            }
+        ],
+    }

--- a/tests/model_generator/test_model_generator.py
+++ b/tests/model_generator/test_model_generator.py
@@ -1048,3 +1048,22 @@ class LogicalTypesNotNested(AvroModel):
     model_generator = ModelGenerator()
     result = model_generator.render(schema=logical_types_not_nested)
     assert result.strip() == expected_result.strip()
+
+
+def test_schema_with_logical_types_not_nested_and_null_default(
+    logical_types_not_nested_with_null_default: types.JsonDict,
+) -> None:
+    expected_result = """
+from dataclasses_avroschema import AvroModel
+import dataclasses
+import datetime
+
+
+@dataclasses.dataclass
+class LogicalTypesNotNestedWithNullDefault(AvroModel):
+    occurrence_date: datetime.datetime = None
+    """
+
+    model_generator = ModelGenerator()
+    result = model_generator.render(schema=logical_types_not_nested_with_null_default)
+    assert result.strip() == expected_result.strip()


### PR DESCRIPTION
Closes #727

Generating a model from a schema whose field has a logical type and a `null` default raised `TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'`, because `get_field_default` handed the default to the logical type converter (`timestamp-millis` divides by 1000) before checking for `None`. A `null` default always renders as `None` regardless of field type, so it is now handled first.

Added `test_schema_with_logical_types_not_nested_and_null_default`, which fails with that exact TypeError without the one-branch fix and passes with it.