### PR TITLE
fix: do not mutate Meta.field_order during schema generation

### DIFF
--- a/dataclasses_avroschema/parser.py
+++ b/dataclasses_avroschema/parser.py
@@ -88,6 +88,10 @@ class Parser:
         field_order = self.metadata.field_order
 
         if field_order is not None:
+            # Work on a copy: `field_order` is the list object defined on the model
+            # (and shared with subclasses through inheritance), so appending to it
+            # would permanently rewrite the user's declared order.
+            field_order = list(field_order)
             for field_name in self.fields_map.keys():
                 if field_name not in field_order:
                     field_order.append(field_name)

--- a/tests/schemas/test_schema.py
+++ b/tests/schemas/test_schema.py
@@ -227,6 +227,32 @@ def test_order_field_not_specifing_all(order_fields_schema):
     assert User.avro_schema() == json.dumps(order_fields_schema)
 
 
+def test_order_field_not_mutated_by_schema_generation(order_fields_schema):
+    """`Meta.field_order` must not be rewritten by generating the schema."""
+
+    @dataclass
+    class User(AvroModel):
+        name: str
+        age: int
+        money: float
+        encoded: bytes
+        has_pets: bool = False
+
+        class Meta:
+            field_order = [
+                "encoded",
+                "has_pets",
+                "money",
+            ]
+
+    User.avro_schema()
+
+    assert User.Meta.field_order == ["encoded", "has_pets", "money"]
+    # regenerating (and generating for a subclass) must still honour the
+    # declared order rather than an order left over from a previous run
+    assert User.avro_schema() == json.dumps(order_fields_schema)
+
+
 def test_exclude_field_from_schema(user_extra_avro_attributes):
     class User(AvroModel):
         "An User"


### PR DESCRIPTION
Closes #786

`get_rendered_fields()` appended the fields missing from `Meta.field_order` straight onto that list, which is the user's own object and is shared with subclasses through inheritance — so generating a schema permanently rewrote the declared order (a later assertion on `Meta.field_order` sees the full field list, and generating a subclass schema appends the subclass fields to the parent's order). The completion list is now built on a copy.

Added `test_order_field_not_mutated_by_schema_generation`, which fails on master with the order rewritten and passes with the fix.
