### PR TITLE
fix: serialize records without fields to avro-json

### DIFF
--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -57,8 +57,13 @@ def serialize(payload: JsonDict, schema: typing.Dict, serialization_type: Serial
         value = file_like_output.getvalue()
     elif serialization_type == AVRO_JSON:
         file_like_output = io.StringIO()
-        fastavro.json_writer(file_like_output, schema, [payload])
-        value = file_like_output.getvalue().encode("utf-8")
+        if schema.get("type") == "record" and not schema.get("fields"):
+            # `fastavro.json_writer` raises an `Internal Parser Exception` when
+            # flushing a record without fields, so encode the empty record directly.
+            value = b"{}"
+        else:
+            fastavro.json_writer(file_like_output, schema, [payload])
+            value = file_like_output.getvalue().encode("utf-8")
     else:
         raise ValueError(f"Serialization type should be `avro` or `avro-json`, not {serialization_type}")
 

--- a/tests/serialization/test_serialization.py
+++ b/tests/serialization/test_serialization.py
@@ -340,3 +340,17 @@ def test_serialization_with_nested_models_and_forward_ref_uuid():
     assert deserialized.inner is not None
     assert deserialized.inner.value == "inner_value"
     assert deserialized.inner.inner_id == inner_uuid
+
+
+def test_schema_without_fields_serialization() -> None:
+    """A record without fields must serialize with both avro and avro-json."""
+
+    @dataclass
+    class EmptyModel(AvroModel):
+        pass
+
+    empty = EmptyModel()
+
+    assert empty.serialize() == b""
+    assert empty.serialize(serialization_type=AVRO_JSON) == b"{}"
+    assert EmptyModel.deserialize(b"{}", serialization_type=AVRO_JSON) == empty


### PR DESCRIPTION
Closes #464

`fastavro.json_writer` raises `Internal Parser Exception` when flushing a record schema with no fields, so `serialize(serialization_type="avro-json")` crashed on a fieldless model while plain avro serialization returned `b""` fine. This encodes the fieldless record as `{}` directly, which round-trips back through `deserialize()`.

Regression test added in `tests/serialization/test_serialization.py` (fails with the exception before the change, passes after).
