### PR TITLE
fix: resolve fields inherited from a plain mixin in standardize_custom_type

### DIFF
--- a/dataclasses_avroschema/utils.py
+++ b/dataclasses_avroschema/utils.py
@@ -196,10 +196,16 @@ def standardize_custom_type(
         else:
             asdict = value.asdict()
 
-        annotations = get_klass_annotations(model.__class__)
+        # A copy, because `get_klass_annotations` hands back the class's own
+        # `__annotations__` and the updates below would otherwise be written into it.
+        annotations = dict(get_klass_annotations(model.__class__))
         # This is a hack to get the annotations from the parent class
         # https://github.com/marcosschroh/dataclasses-avroschema/issues/800
-        if model.__class__.mro()[1] != base_class:
+        #
+        # The field can also be inherited from a plain mixin, which the check above misses
+        # when the model subclasses the base class directly, so the hints are resolved on
+        # a miss as well rather than letting the lookup raise `KeyError`.
+        if model.__class__.mro()[1] != base_class or field_name not in annotations:
             annotations.update(typing.get_type_hints(model.__class__))
 
         if is_union(annotations[field_name]) and include_type and not inside_collection:

--- a/tests/serialization/test_inherited_annotations.py
+++ b/tests/serialization/test_inherited_annotations.py
@@ -1,0 +1,40 @@
+import dataclasses
+
+from dataclasses_avroschema import AvroModel
+from dataclasses_avroschema.utils import get_klass_annotations
+
+
+@dataclasses.dataclass
+class Nested(AvroModel):
+    n: str = "n"
+
+
+@dataclasses.dataclass
+class Mixin:
+    inner: Nested = dataclasses.field(default_factory=Nested)
+
+
+@dataclasses.dataclass
+class Model(AvroModel, Mixin):
+    own: str = "y"
+
+
+def test_asdict_resolves_a_field_inherited_from_a_mixin() -> None:
+    """
+    `standardize_custom_type` reads the model's own `__annotations__` and only falls back
+    to `get_type_hints` when the model does not subclass the base class directly. A model
+    that subclasses it directly *and* takes a field from a mixin skipped that fallback and
+    raised `KeyError`.
+    """
+    assert Model.mro()[1] is AvroModel
+
+    assert Model().asdict() == {"own": "y", "inner": {"n": "n"}}
+
+
+def test_asdict_does_not_write_into_the_class_annotations() -> None:
+    """The fallback used to merge the resolved hints into the class's own dict."""
+    before = dict(get_klass_annotations(Model))
+
+    Model().asdict()
+
+    assert dict(get_klass_annotations(Model)) == before


### PR DESCRIPTION
Hi Marcos — as discussed by email, I am sending the items that belong in the public repo as small, separate PRs so they are easy to review one at a time. This is the first one.

## The problem

`standardize_custom_type()` looks a field up in the model's own `__annotations__`, and only falls back to `typing.get_type_hints()` when the model does **not** subclass `AvroModel` directly (the `mro()[1] != base_class` check added for #800).

A model that subclasses `AvroModel` directly **and** takes a nested-model field from a plain (non-`AvroModel`) mixin satisfies neither path: the field is not in the class's own annotations, and the fallback never runs. The lookup then raises `KeyError` on `asdict()` and `serialize()`.

```python
@dataclasses.dataclass
class Nested(AvroModel):
    n: str = "n"

@dataclasses.dataclass
class Mixin:
    inner: Nested = dataclasses.field(default_factory=Nested)

@dataclasses.dataclass
class Model(AvroModel, Mixin):
    own: str = "y"

Model().asdict()   # KeyError: 'inner'  (on master)
```

There is a second, smaller defect on the same lines: the fallback calls `annotations.update(...)` on the dictionary returned by `get_klass_annotations()`, which **is** the class's own `__annotations__` object. So calling `asdict()` writes the resolved hints into the class itself.

## The change

Two lines in `dataclasses_avroschema/utils.py`:

1. The fallback also runs when the field is simply not present in the annotations, instead of letting the lookup raise — so a mixin-inherited field resolves like any other.
2. `annotations` is a copy, so `asdict()` no longer mutates the class.

Behaviour is unchanged for every model that worked before: the fallback is strictly additive, and it only fires on a miss.

## Tests

`tests/serialization/test_inherited_annotations.py` — two tests:

- `test_asdict_resolves_a_field_inherited_from_a_mixin` — the case above. It asserts `Model.mro()[1] is AvroModel` first, so the test still covers the intended path if the class layout is ever changed.
- `test_asdict_does_not_write_into_the_class_annotations` — snapshots the annotations, calls `asdict()`, and compares.

Both fail on `master` with `KeyError: 'inner'` and pass with the change.

## Verification

Run locally on Python 3.11 against this branch:

- `pytest tests` — **2884 passed, 2 skipped, 4 xfailed** (baseline plus the two new tests; nothing else moved)
- `mypy dataclasses_avroschema` — clean, 37 source files
- `ruff check` and `ruff format --check` — clean

Happy to adjust naming, test placement, or anything else you would rather see done differently.
