### PR TITLE
fix: bound the decimal precision and payload accepted from a schema

### DIFF
--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import enum
 import io
+import math
 import typing
 import uuid
 
@@ -18,6 +19,12 @@ AVRO = "avro"
 AVRO_JSON = "avro-json"
 
 decimal_context = decimal.Context()
+
+# The avro spec bounds a decimal's `precision` by the size of its payload rather than by
+# an absolute value, so a schema can ask for any number of digits. `create_decimal` and
+# `scaleb` both cost more as that number grows. This is the largest value accepted from a
+# schema; raise it if a use case genuinely needs more digits than this.
+MAX_DECIMAL_PRECISION = 1000
 
 
 def serialize(payload: JsonDict, schema: typing.Dict, serialization_type: SerializationType = "avro") -> bytes:
@@ -191,20 +198,56 @@ def decimal_to_str(value: decimal.Decimal, precision: int, scale: int = 0) -> st
     return r"\u" + value_bytes.hex()
 
 
+def max_decimal_bytes(*, precision: int, scale: int) -> int:
+    """The most bytes the unscaled value of a decimal with this precision can occupy.
+
+    `prepare_bytes_decimal` multiplies the unscaled value by `10 ** (exp + scale)` before
+    encoding it, so up to `scale` further digits can legitimately appear on the wire.
+    """
+    digits = precision + scale
+    bits = math.ceil(digits * math.log2(10)) + 1  # + 1 for the sign bit
+
+    return (bits + 7) // 8
+
+
 def string_to_decimal(*, value: str, schema: JsonDict) -> decimal.Decimal:
+    scale = schema.get("scale", 0)
+    precision = schema["precision"]
+
+    if not isinstance(precision, int) or isinstance(precision, bool) or precision <= 0:
+        raise ValueError(f"`precision` must be a positive integer, not {precision!r}")
+
+    if precision > MAX_DECIMAL_PRECISION:
+        raise ValueError(
+            f"`precision` is {precision}, above the maximum of {MAX_DECIMAL_PRECISION} "
+            "(`serialization.MAX_DECIMAL_PRECISION`)"
+        )
+
+    if not isinstance(scale, int) or isinstance(scale, bool) or not 0 <= scale <= precision:
+        raise ValueError(f"`scale` must be an integer between zero and the precision, not {scale!r}")
+
     # first remove the Unicode character
     value = value.replace(r"\u", "")
 
     # then concert to bytes
     decimal_bytes = bytes.fromhex(value)
 
-    # finally get the decimal.Decimal
-    scale = schema.get("scale", 0)
-    precision = schema["precision"]
-    unscaled_datum = int.from_bytes(decimal_bytes, byteorder="big", signed=True)
-    decimal_context.prec = precision
+    # A payload longer than the precision allows is not a decimal this schema can describe,
+    # and the cost of turning it into one grows with its length.
+    max_bytes = max_decimal_bytes(precision=precision, scale=scale)
+    if len(decimal_bytes) > max_bytes:
+        raise ValueError(
+            f"The decimal value is {len(decimal_bytes)} bytes, which does not fit in the "
+            f"{precision} digits declared by the schema (at most {max_bytes} bytes)"
+        )
 
-    return decimal_context.create_decimal(unscaled_datum).scaleb(-scale, decimal_context)
+    # finally get the decimal.Decimal. The context is local because `decimal_context` is
+    # module level: assigning to its `prec` also changed the precision of unrelated decimal
+    # work elsewhere in the process.
+    context = decimal.Context(prec=precision)
+    unscaled_datum = int.from_bytes(decimal_bytes, byteorder="big", signed=True)
+
+    return context.create_decimal(unscaled_datum).scaleb(-scale, context)
 
 
 # This is an almost complete copy of fastavro's _logical_writers_py.prepare_bytes_decimal

--- a/tests/serialization/test_decimal_bounds.py
+++ b/tests/serialization/test_decimal_bounds.py
@@ -1,0 +1,81 @@
+import decimal
+
+import pytest
+
+from dataclasses_avroschema import serialization
+
+
+def test_a_decimal_round_trips_unchanged() -> None:
+    value = decimal.Decimal("3.14")
+
+    encoded = serialization.decimal_to_str(value, precision=3, scale=2)
+
+    assert serialization.string_to_decimal(value=encoded, schema={"precision": 3, "scale": 2}) == value
+
+
+def test_the_module_level_context_is_left_alone() -> None:
+    """`decimal_context` is shared, so writing the schema's precision into it changed the
+    precision of unrelated decimal work elsewhere in the process."""
+    before = serialization.decimal_context.prec
+
+    serialization.string_to_decimal(value="0141", schema={"precision": 5, "scale": 2})
+
+    assert serialization.decimal_context.prec == before
+
+
+def test_precision_above_the_maximum_is_rejected() -> None:
+    schema = {"precision": serialization.MAX_DECIMAL_PRECISION + 1, "scale": 1}
+
+    with pytest.raises(ValueError, match="above the maximum"):
+        serialization.string_to_decimal(value="01" * 8, schema=schema)
+
+
+def test_precision_at_the_maximum_is_accepted() -> None:
+    schema = {"precision": serialization.MAX_DECIMAL_PRECISION, "scale": 0}
+
+    assert serialization.string_to_decimal(value="01", schema=schema) == decimal.Decimal(1)
+
+
+@pytest.mark.parametrize("precision", [0, -1, 3.5, "3", True, None])
+def test_a_precision_that_is_not_a_positive_integer_is_rejected(precision) -> None:
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        serialization.string_to_decimal(value="01", schema={"precision": precision, "scale": 0})
+
+
+@pytest.mark.parametrize("scale", [-1, 4, 1.5, "1", True, None])
+def test_a_scale_outside_the_precision_is_rejected(scale) -> None:
+    with pytest.raises(ValueError, match="`scale` must be an integer"):
+        serialization.string_to_decimal(value="01", schema={"precision": 3, "scale": scale})
+
+
+def test_a_payload_larger_than_the_precision_allows_is_rejected() -> None:
+    """The hex payload is schema-controlled too, and the cost of decoding it grows with its
+    length, so a value that cannot fit in the declared digits is refused up front."""
+    schema = {"precision": 3, "scale": 0}
+
+    with pytest.raises(ValueError, match="does not fit in the 3 digits"):
+        serialization.string_to_decimal(value="01" * 64, schema=schema)
+
+
+def test_the_payload_bound_accepts_everything_the_writer_produces() -> None:
+    """`prepare_bytes_decimal` scales the unscaled value up before encoding, so the bound
+    has to leave room for that."""
+    precision, scale = 9, 4
+    value = decimal.Decimal("12345.6789")
+
+    encoded = serialization.decimal_to_str(value, precision=precision, scale=scale)
+
+    assert serialization.string_to_decimal(value=encoded, schema={"precision": precision, "scale": scale}) == value
+
+
+@pytest.mark.parametrize(("precision", "scale"), [(1, 0), (3, 2), (9, 4), (18, 6), (38, 10)])
+def test_max_decimal_bytes_matches_the_writer(precision: int, scale: int) -> None:
+    """The largest value the writer can emit for these settings must fit inside the bound."""
+    digits = decimal.Decimal(10) ** precision - 1
+    value = digits.scaleb(-scale)
+
+    encoded = serialization.decimal_to_str(value, precision=precision, scale=scale)
+
+    assert len(bytes.fromhex(encoded.replace(r"\u", ""))) <= serialization.max_decimal_bytes(
+        precision=precision, scale=scale
+    )


### PR DESCRIPTION
Hi Marcos — this is the "maximum decimal precision" item from your list, sent as its own PR so the limit can be discussed on its own.

## The problem

`serialization.string_to_decimal()` reads two values straight from the schema and bounds neither:

```python
decimal_bytes = bytes.fromhex(value)          # any length
precision = schema["precision"]               # any value
decimal_context.prec = precision
return decimal_context.create_decimal(unscaled_datum).scaleb(-scale, decimal_context)
```

It is reached from `ModelGenerator.render()` through `parse_logical_type()` → `parse_decimal()` when a decimal field carries a default, so a schema being turned into a model decides how much work the call does.

There is a second effect worth mentioning: `decimal_context` is a **module-level** object, so `decimal_context.prec = precision` raises the working precision for every later decimal operation in the process that uses it, not only for this call.

## The change

1. `precision` must be a positive integer and is capped at `MAX_DECIMAL_PRECISION`, a module-level constant set to **1000**. I picked a number far above realistic use (SQL `DECIMAL` and most avro producers stop at 38) so that no working schema hits it; it is a plain module attribute, so anyone who needs more can raise it. **Very happy to change the value, the name, or the shape** — if you would rather it lived on a settings object, or be passed in by the caller, say the word and I will redo it that way.
2. `scale` must be an integer between zero and the precision. That is the avro rule and it is also what `DecimalField.set_precision_scale()` already enforces on the model side; the reader accepted anything.
3. A payload larger than the declared digits can hold is rejected before it is decoded. The bound is derived, not guessed: `max_decimal_bytes()` computes it from `precision + scale`, with the `+ scale` headroom because `prepare_bytes_decimal()` scales the unscaled value up before encoding it. A test asserts the bound accepts the largest value the writer can produce for a range of precision/scale pairs, so the reader cannot become stricter than the writer.
4. The precision is applied to a **local** `decimal.Context`, leaving the module-level `decimal_context` untouched. The results are identical — the old code assigned `prec` on every call anyway — but the side effect on unrelated decimal work is gone. `decimal_context` itself is kept, since it is a public module attribute.

## Effect

With the change, an oversized schema is refused immediately instead of being processed:

| hex payload | `precision` | before | after |
|---|---|---|---|
| 4 000 chars | 4 000 | seconds of CPU | `ValueError` in microseconds |
| 64 000 chars | 64 000 | tens of seconds | `ValueError` in microseconds |

## Tests

`tests/serialization/test_decimal_bounds.py` — 23 cases covering: an ordinary decimal still round-trips through `decimal_to_str` → `string_to_decimal`; the module-level context is left alone; precision above the cap, at the cap, and not a positive integer; scale outside its range; an oversized payload; and the writer/reader agreement check described above. 21 of the 23 fail on `master`.

## Verification

Run locally on Python 3.11 against this branch:

- `pytest tests` — **2905 passed, 2 skipped, 4 xfailed** (baseline plus the new tests; nothing else moved)
- `mypy dataclasses_avroschema` — clean, 37 source files
- `ruff check` and `ruff format --check` — clean

One note on backwards compatibility: this makes `string_to_decimal` raise `ValueError` for schemas it previously accepted — ones asking for more than 1000 digits, ones whose scale is outside the precision, and ones whose payload does not fit. All three are schemas the avro spec does not allow, and the whole existing suite passes unchanged, but it is a behaviour change and I would rather flag it than have you find it.
