### PR TITLE
fix: bound the sizes fake() will build for fixed and decimal fields

### DIFF
--- a/dataclasses_avroschema/fields/fields.py
+++ b/dataclasses_avroschema/fields/fields.py
@@ -67,7 +67,15 @@ __all__ = [
     "DecimalField",
     "RecordField",
     "AvroField",
+    "MAX_FAKE_FIXED_SIZE",
+    "MAX_FAKE_DECIMAL_DIGITS",
 ]
+
+# `fake()` builds a value as large as the field says it is, and for a model generated from
+# a schema both of these numbers come from that schema. These are the largest values it
+# will build; both are module level, so a project that needs bigger fixtures can raise them.
+MAX_FAKE_FIXED_SIZE = 65_536  # bytes
+MAX_FAKE_DECIMAL_DIGITS = 1_000  # digits
 
 
 class ImmutableField(Field):
@@ -456,6 +464,12 @@ class FixedField(BytesField):
         return True
 
     def fake(self) -> bytes:
+        if self.size > MAX_FAKE_FIXED_SIZE:
+            raise ValueError(
+                f"Can not fake a `fixed` field of {self.size} bytes, above the maximum of "
+                f"{MAX_FAKE_FIXED_SIZE} (`fields.MAX_FAKE_FIXED_SIZE`)"
+            )
+
         return fake.pystr(max_chars=self.size).encode()
 
 
@@ -923,6 +937,12 @@ class DecimalField(Field):
         return serialization.decimal_to_str(default, self.max_digits, self.decimal_places)
 
     def fake(self) -> decimal.Decimal:
+        if self.max_digits > MAX_FAKE_DECIMAL_DIGITS:
+            raise ValueError(
+                f"Can not fake a decimal of {self.max_digits} digits, above the maximum of "
+                f"{MAX_FAKE_DECIMAL_DIGITS} (`fields.MAX_FAKE_DECIMAL_DIGITS`)"
+            )
+
         return fake.pydecimal(
             right_digits=self.decimal_places,
             left_digits=self.max_digits - self.decimal_places,

--- a/tests/fake/test_fake_bounds.py
+++ b/tests/fake/test_fake_bounds.py
@@ -1,0 +1,72 @@
+import dataclasses
+import decimal
+
+import pytest
+
+from dataclasses_avroschema import AvroModel, types
+from dataclasses_avroschema.fields import fields
+
+
+def test_a_fixed_field_of_ordinary_size_is_faked() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        md5: types.confixed(size=16)  # type: ignore[valid-type]
+
+    assert len(User.fake().md5) == 16
+
+
+def test_a_fixed_field_above_the_maximum_is_refused() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        md5: types.confixed(size=fields.MAX_FAKE_FIXED_SIZE + 1)  # type: ignore[valid-type]
+
+    with pytest.raises(ValueError, match="above the maximum"):
+        User.fake()
+
+
+def test_a_fixed_field_at_the_maximum_is_faked() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        md5: types.confixed(size=fields.MAX_FAKE_FIXED_SIZE)  # type: ignore[valid-type]
+
+    assert len(User.fake().md5) == fields.MAX_FAKE_FIXED_SIZE
+
+
+def test_a_decimal_field_of_ordinary_size_is_faked() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        score: types.condecimal(max_digits=11, decimal_places=5)  # type: ignore[valid-type]
+
+    assert isinstance(User.fake().score, decimal.Decimal)
+
+
+def test_a_decimal_field_above_the_maximum_is_refused() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        score: types.condecimal(  # type: ignore[valid-type]
+            max_digits=fields.MAX_FAKE_DECIMAL_DIGITS + 1, decimal_places=2
+        )
+
+    with pytest.raises(ValueError, match="above the maximum"):
+        User.fake()
+
+
+def test_a_decimal_field_at_the_maximum_is_faked() -> None:
+    @dataclasses.dataclass
+    class User(AvroModel):
+        score: types.condecimal(  # type: ignore[valid-type]
+            max_digits=fields.MAX_FAKE_DECIMAL_DIGITS, decimal_places=2
+        )
+
+    assert isinstance(User.fake().score, decimal.Decimal)
+
+
+def test_the_schema_is_unaffected_by_the_bound() -> None:
+    """The limit belongs to `fake()` only: a model with a large `fixed` still serialises and
+    still produces the same avro schema."""
+
+    @dataclasses.dataclass
+    class User(AvroModel):
+        md5: types.confixed(size=fields.MAX_FAKE_FIXED_SIZE + 1)  # type: ignore[valid-type]
+
+    assert User.avro_schema_to_python()["fields"][0]["type"]["size"] == fields.MAX_FAKE_FIXED_SIZE + 1


### PR DESCRIPTION
Hi Marcos — this is the "bound on the `fake()` sizes" item, as its own PR.

## The problem

Two `fake()` implementations build a value as large as the field says it is, and neither number is bounded:

```python
class FixedField(BytesField):
    def fake(self) -> bytes:
        return fake.pystr(max_chars=self.size).encode()

class DecimalField(Field):
    def fake(self) -> decimal.Decimal:
        return fake.pydecimal(right_digits=self.decimal_places, left_digits=self.max_digits - self.decimal_places)
```

`size` and `max_digits` come from `confixed()` / `condecimal()`, which for a model produced by `ModelGenerator` come from the schema. `set_precision_scale()` already rejects `max_digits <= 0` and a `decimal_places` above the precision, but has no upper bound; `set_fixed()` stores `size` verbatim.

Measured on `master`, Python 3.11, for `fake()` on a single `fixed` field:

| declared `size` | wall time | peak memory |
|---|---|---|
| 1 000 000 | 0.044 s | 9.5 MB |
| 10 000 000 | 0.637 s | 99.1 MB |

I would rather be precise than dramatic about this one: at realistic sizes the cost is small, and I am **not** claiming an outage. What the numbers do show is that memory tracks the declared size at roughly ten bytes per byte (faker builds a `str` of `size` characters and then encodes it), so the ceiling is set by whoever wrote the schema rather than by the library — a `size` of a billion asks for tens of gigabytes.

## The change

Two module-level constants in `dataclasses_avroschema/fields/fields.py`:

```python
MAX_FAKE_FIXED_SIZE = 65_536      # bytes
MAX_FAKE_DECIMAL_DIGITS = 1_000   # digits
```

`FixedField.fake()` and `DecimalField.fake()` raise `ValueError` above them, naming the constant in the message so the way out is obvious.

Two deliberate choices, both easy to change if you would rather have it otherwise:

1. **The check lives in `fake()`, not in `set_fixed()` / `set_precision_scale()`.** A large `fixed` field is perfectly valid avro, and models that only serialise are not affected by any of this — putting the limit at model-definition time would break users who never call `fake()`. So schema generation, serialisation and validation are untouched; a test asserts the generated schema still carries the full declared size.
2. **It raises rather than clamping.** A `fixed` is exactly `size` bytes, so silently generating a shorter value would hand back a fixture that does not match its own schema.

The values are generous on purpose — 64 KiB is far above any real `fixed` field (`md5` is 16), and 1000 digits is far above any real decimal (SQL `DECIMAL` and most avro producers stop at 38). Happy to change the numbers, the names, or move both onto a settings object if you prefer that shape.

## Tests

`tests/fake/test_fake_bounds.py` — 7 cases: ordinary sizes still fake correctly; at the limit works; above the limit raises for both field types; and the generated schema is unaffected by the bound.

These reference the new constants, so on `master` they fail with `AttributeError` rather than by proving anything — the before/after evidence is the table above, not the test run.

## Verification

Run locally on Python 3.11 against this branch:

- `pytest tests` — **2889 passed, 2 skipped, 4 xfailed** (baseline plus the new tests; nothing else moved)
- `mypy dataclasses_avroschema` — clean, 37 source files
- `ruff check` and `ruff format --check` — clean
