### PR TITLE
fix: bound the recursion depth of the model generator and the deserializer

### DIFF
--- a/dataclasses_avroschema/model_generator/lang/python/base.py
+++ b/dataclasses_avroschema/model_generator/lang/python/base.py
@@ -18,6 +18,13 @@ from . import (
     templates,
 )
 
+# `render_field` walks the schema by calling itself, so the schema decides how deep the
+# interpreter's stack goes. Nesting arrays or maps a few thousand levels deep is a small
+# document to write and a `RecursionError` to render, which is why the depth is bounded
+# here rather than left to the interpreter. Pass `max_nesting_depth` to the generator to
+# change it.
+MAX_NESTING_DEPTH = 100
+
 
 @dataclasses.dataclass
 class FieldRepresentation:
@@ -386,6 +393,8 @@ class BaseGenerator:
     include_original_schema: bool = False
     base_class: str = field(init=False)
     type_hint_clashes: dict[str, str] = field(default_factory=dict)
+    max_nesting_depth: int = MAX_NESTING_DEPTH
+    _nesting_depth: int = field(default=0, init=False)
 
     def __post_init__(self) -> None:
         self.avro_type_to_lang = avro_to_python_utils.AVRO_TYPE_TO_PYTHON
@@ -458,6 +467,25 @@ class BaseGenerator:
         return class_representation
 
     def render_field(self, field: JsonDict, model_name: str, parent_field_name: str) -> FieldRepresentation:
+        """
+        Render an avro field, refusing to go deeper than `max_nesting_depth`.
+
+        The depth is tracked here because every nesting shape — a nested record, an array,
+        a map, a union — comes back through this method.
+        """
+        if self._nesting_depth >= self.max_nesting_depth:
+            raise ValueError(
+                f"The schema is nested more than {self.max_nesting_depth} levels deep. "
+                "Set `max_nesting_depth` on the generator if this schema is legitimate."
+            )
+
+        self._nesting_depth += 1
+        try:
+            return self._render_field(field=field, model_name=model_name, parent_field_name=parent_field_name)
+        finally:
+            self._nesting_depth -= 1
+
+    def _render_field(self, field: JsonDict, model_name: str, parent_field_name: str) -> FieldRepresentation:
         """
         Render an avro field.
 

--- a/dataclasses_avroschema/serialization.py
+++ b/dataclasses_avroschema/serialization.py
@@ -19,6 +19,10 @@ AVRO_JSON = "avro-json"
 
 decimal_context = decimal.Context()
 
+# The deepest payload `deserialize_from_context` will walk. A recursive schema lets the
+# payload, rather than the schema, decide how deep the nesting goes.
+MAX_DESERIALIZE_DEPTH = 100
+
 
 def serialize(payload: JsonDict, schema: typing.Dict, serialization_type: SerializationType = "avro") -> bytes:
     """
@@ -143,27 +147,37 @@ def deserialize(
     return payload  # type: ignore
 
 
-def deserialize_from_context(*, data: typing.Any, context: JsonDict) -> typing.Any:
+def deserialize_from_context(*, data: typing.Any, context: JsonDict, depth: int = 0) -> typing.Any:
     """
     Recursively normalize deserialized data: unwrap union tuples
     produced by fastavro's return_record_name=True, and recurse into
     dicts and lists so that all nesting shapes are handled consistently.
+
+    A recursive schema puts the nesting depth in the hands of the payload, so the walk is
+    bounded by `MAX_DESERIALIZE_DEPTH` and reports going past it as a `ValueError` instead
+    of as a `RecursionError` raised somewhere further down.
     """
+    if depth > MAX_DESERIALIZE_DEPTH:
+        raise ValueError(
+            f"The payload is nested more than {MAX_DESERIALIZE_DEPTH} levels deep "
+            "(`serialization.MAX_DESERIALIZE_DEPTH`)"
+        )
+
     if isinstance(data, dict):
-        return {k: deserialize_from_context(data=v, context=context) for k, v in data.items()}
+        return {k: deserialize_from_context(data=v, context=context, depth=depth + 1) for k, v in data.items()}
     elif isinstance(data, tuple) and len(data) == 2:
-        return sanitize_union(union=data, context=context)
+        return sanitize_union(union=data, context=context, depth=depth)
     elif isinstance(data, list):
-        return [deserialize_from_context(data=item, context=context) for item in data]
+        return [deserialize_from_context(data=item, context=context, depth=depth + 1) for item in data]
     return data
 
 
-def sanitize_union(*, union: typing.Tuple, context: JsonDict) -> typing.Optional[ModelProtocol]:
+def sanitize_union(*, union: typing.Tuple, context: JsonDict, depth: int = 0) -> typing.Optional[ModelProtocol]:
     # the first value is the model/record name and the second is its payload
     model_name, model_value = union
     if isinstance(model_value, dict):
         # it can be a dict again so we need to sanitize
-        model_value = deserialize_from_context(data=model_value, context=context)
+        model_value = deserialize_from_context(data=model_value, context=context, depth=depth + 1)
 
     model_name = model_name.split(".")[-1]
     avro_model: typing.Optional[ModelProtocol] = context.get(model_name)

--- a/tests/model_generator/test_nesting_depth.py
+++ b/tests/model_generator/test_nesting_depth.py
@@ -1,0 +1,57 @@
+import typing
+
+import pytest
+
+from dataclasses_avroschema import ModelGenerator, ModelType, types
+from dataclasses_avroschema.model_generator.lang.python import base
+
+
+def nested_array_schema(depth: int) -> types.JsonDict:
+    """A record whose single field is `depth` arrays deep."""
+    field_type: typing.Any = "string"
+    for _ in range(depth):
+        field_type = {"type": "array", "items": field_type}
+
+    return {
+        "type": "record",
+        "name": "Deep",
+        "fields": [{"name": "nested", "type": field_type}],
+    }
+
+
+def test_an_ordinary_schema_still_renders() -> None:
+    result = ModelGenerator().render(schema=nested_array_schema(3), model_type=ModelType.DATACLASS.value)
+
+    assert "typing.List[typing.List[typing.List[str]]]" in result
+
+
+def test_a_schema_nested_past_the_maximum_is_refused() -> None:
+    schema = nested_array_schema(base.MAX_NESTING_DEPTH + 50)
+
+    with pytest.raises(ValueError, match="nested more than"):
+        ModelGenerator().render(schema=schema, model_type=ModelType.DATACLASS.value)
+
+
+def test_the_maximum_can_be_raised_on_the_generator() -> None:
+    depth = base.MAX_NESTING_DEPTH + 50
+    model_generator = ModelGenerator()
+    generator = model_generator.model_type_mapper[ModelType.DATACLASS.value]
+    generator.max_nesting_depth = depth + 10
+
+    result = model_generator.render(schema=nested_array_schema(depth), model_type=ModelType.DATACLASS.value)
+
+    assert result.count("typing.List") == depth
+
+
+def test_the_depth_is_released_between_renders() -> None:
+    """The counter lives on the generator, and generators are reused, so it has to unwind
+    even when a render fails."""
+    model_generator = ModelGenerator()
+
+    with pytest.raises(ValueError, match="nested more than"):
+        model_generator.render(
+            schema=nested_array_schema(base.MAX_NESTING_DEPTH + 50), model_type=ModelType.DATACLASS.value
+        )
+
+    generator = model_generator.model_type_mapper[ModelType.DATACLASS.value]
+    assert generator._nesting_depth == 0

--- a/tests/serialization/test_deserialize_depth.py
+++ b/tests/serialization/test_deserialize_depth.py
@@ -1,0 +1,54 @@
+import typing
+
+import pytest
+
+from dataclasses_avroschema import serialization
+
+
+def nested_payload(depth: int) -> typing.Any:
+    data: typing.Any = {"leaf": 1}
+    for _ in range(depth):
+        data = {"nested": data}
+
+    return data
+
+
+def test_an_ordinary_payload_is_normalised_as_before() -> None:
+    data = {"name": "marcos", "pets": [{"name": "dog"}, {"name": "cat"}]}
+
+    assert serialization.deserialize_from_context(data=data, context={}) == data
+
+
+def test_a_payload_nested_past_the_maximum_is_refused() -> None:
+    """A recursive schema lets the payload choose the depth, and the walk used to run until
+    the interpreter stopped it with a `RecursionError`."""
+    data = nested_payload(serialization.MAX_DESERIALIZE_DEPTH + 50)
+
+    with pytest.raises(ValueError, match="nested more than"):
+        serialization.deserialize_from_context(data=data, context={})
+
+
+def test_a_payload_at_the_maximum_is_accepted() -> None:
+    data = nested_payload(serialization.MAX_DESERIALIZE_DEPTH - 1)
+
+    assert serialization.deserialize_from_context(data=data, context={}) == data
+
+
+def test_lists_count_towards_the_depth() -> None:
+    data: typing.Any = 1
+    for _ in range(serialization.MAX_DESERIALIZE_DEPTH + 50):
+        data = [data]
+
+    with pytest.raises(ValueError, match="nested more than"):
+        serialization.deserialize_from_context(data=data, context={})
+
+
+def test_records_inside_unions_count_towards_the_depth() -> None:
+    """A record reached through a union is walked by `sanitize_union`, which comes back
+    here, so that path has to be counted as well."""
+    data: typing.Any = {"leaf": 1}
+    for _ in range(serialization.MAX_DESERIALIZE_DEPTH):
+        data = {"nested": ("Record", data)}
+
+    with pytest.raises(ValueError, match="nested more than"):
+        serialization.deserialize_from_context(data=data, context={})


### PR DESCRIPTION
Hi Marcos — this is the "recursion depth" item. There are two recursive walks that a schema or a payload can drive, so the PR has one commit for each; happy to split it into two PRs if you would rather review them separately.

## 1. The model generator — `BaseGenerator.render_field`

`render_field` walks the schema by calling itself: a nested record, an array, a map and a union all come back through it. Nothing bounds that, so the schema decides how deep the interpreter's stack goes, and a document nesting arrays a few thousand levels deep — a few kilobytes to write — ends the render in a `RecursionError` raised from wherever the stack ran out.

The depth is now tracked on the generator, and `render_field` refuses to go past `max_nesting_depth`, a field on `BaseGenerator` defaulting to the module-level `MAX_NESTING_DEPTH = 100`:

```python
model_generator.model_type_mapper[ModelType.DATACLASS.value].max_nesting_depth = 500
```

The existing body moved unchanged to `_render_field`; the public `render_field` signature and behaviour are the same, and the counter unwinds in a `finally`, so a failed render leaves the generator reusable (there is a test for that, since the generators are reused across calls).

## 2. Deserialization — `deserialize_from_context`

`deserialize_from_context` recurses through dicts, lists and union tuples to normalise a payload. With a **recursive schema** the nesting depth comes from the payload rather than from the schema, so a deep enough payload ends deserialization in a `RecursionError`.

The walk now carries its depth and stops at `MAX_DESERIALIZE_DEPTH = 100` with a `ValueError` naming the constant. `sanitize_union` passes the depth through, because a record reached by way of a union comes back into the same walk — writing the test for that path is what showed it needed to be counted too.

Both are plain module-level constants and I have kept them independent of each other. If you would prefer a single shared setting, or these on a config object, say so and I will restructure.

## What changes for a caller

The failure mode, not the outcome: schemas and payloads that worked still work, and ones that used to crash now raise `ValueError` with a message that says which knob to turn. Running the original nesting reproducer against this branch:

```
depth 10    ok
depth 50    ok
depth 100   ValueError: The schema is nested more than 100 levels deep.
            Set `max_nesting_depth` on the generator if this schema is legitimate.
```

100 is deliberately far above real schemas — the deepest in the test suite is single digits — and it is adjustable in both places.

## Tests

- `tests/model_generator/test_nesting_depth.py` — 4 cases: an ordinary schema still renders; past the limit raises; the limit can be raised on the generator; the counter unwinds after a failed render.
- `tests/serialization/test_deserialize_depth.py` — 5 cases: an ordinary payload is normalised as before; at the limit works; past the limit raises; lists count; records reached through unions count.

## Verification

Run locally on Python 3.11 against this branch:

- `pytest tests` — **2891 passed, 2 skipped, 4 xfailed** (baseline plus the new tests; nothing else moved)
- `mypy dataclasses_avroschema` — clean, 37 source files
- `ruff check` and `ruff format --check` — clean
